### PR TITLE
Change minimum value for audio buffering option

### DIFF
--- a/rpcs3/Emu/system_config.h
+++ b/rpcs3/Emu/system_config.h
@@ -213,7 +213,7 @@ struct cfg_root : cfg::node
 		cfg::_int<1, 128> startt{ this, "Start Threshold", 1 }; // TODO: used only by ALSA, should probably be removed once ALSA is upgraded
 		cfg::_int<0, 200> volume{ this, "Master Volume", 100 };
 		cfg::_bool enable_buffering{ this, "Enable Buffering", true };
-		cfg::_int <20, 250> desired_buffer_duration{ this, "Desired Audio Buffer Duration", 100 };
+		cfg::_int <0, 250> desired_buffer_duration{ this, "Desired Audio Buffer Duration", 100 };
 		cfg::_int<1, 1000> sampling_period_multiplier{ this, "Sampling Period Multiplier", 100 };
 		cfg::_bool enable_time_stretching{ this, "Enable Time Stretching", false };
 		cfg::_int<0, 100> time_stretching_threshold{ this, "Time Stretching Threshold", 75 };


### PR DESCRIPTION
This was initially addressed on Discord, but at the current lower bound (20ms) of audio buffering, it would introduce audio delay in 60fps games. This simply removes sets the minimum value to 0, which should fix the audio delay issue.