### PR TITLE
Dimensions: use RAII for m_dimensions_mutex in load/remove_figure

### DIFF
--- a/rpcs3/Emu/Io/Dimensions.cpp
+++ b/rpcs3/Emu/Io/Dimensions.cpp
@@ -364,9 +364,10 @@ void dimensions_toypad::get_model(const u8* buf, u8 sequence, std::array<u8, 32>
 
 u32 dimensions_toypad::load_figure(const std::array<u8, 0x2D * 0x04>& buf, fs::file in_file, u8 pad, u8 index, bool lock)
 {
+	std::unique_lock dimensions_lock(m_dimensions_mutex, std::defer_lock);
 	if (lock)
 	{
-		m_dimensions_mutex.lock();
+		dimensions_lock.lock();
 	}
 
 	const u32 id = get_figure_id(buf);
@@ -384,24 +385,21 @@ u32 dimensions_toypad::load_figure(const std::array<u8, 0x2D * 0x04>& buf, fs::f
 	figure_change_response[13] = generate_checksum(figure_change_response, 13);
 	m_figure_added_removed_responses.push(std::move(figure_change_response));
 
-	if (lock)
-	{
-		m_dimensions_mutex.unlock();
-	}
 	return id;
 }
 
 bool dimensions_toypad::remove_figure(u8 pad, u8 index, bool full_remove, bool lock)
 {
+	std::unique_lock dimensions_lock(m_dimensions_mutex, std::defer_lock);
+	if (lock)
+	{
+		dimensions_lock.lock();
+	}
+
 	dimensions_figure& figure = get_figure_by_index(index);
 	if (figure.index == 255)
 	{
 		return false;
-	}
-
-	if (lock)
-	{
-		m_dimensions_mutex.lock();
 	}
 
 	// When a figure is removed from the toypad, respond to the game with the pad they were removed from, their index,
@@ -421,10 +419,6 @@ bool dimensions_toypad::remove_figure(u8 pad, u8 index, bool full_remove, bool l
 	figure.pad = 255;
 	figure.id = 0;
 
-	if (lock)
-	{
-		m_dimensions_mutex.unlock();
-	}
 	return true;
 }
 


### PR DESCRIPTION
## Summary

Two small fixes in `dimensions_toypad`:

1. **Exception-safe locking** — `load_figure` and `remove_figure` previously took `m_dimensions_mutex` via a manual `mutex.lock()` / `mutex.unlock()` pair when called with `lock=true`. If `figure.save()` or `figure.dim_file.close()` (both fs operations that can in principle throw) escaped, the unlock was skipped and the mutex was permanently held. Switched both functions to `std::unique_lock` with `std::defer_lock`, matching the established pattern already used in `vfs::host::rename` and `emulated_logitech_g27_config::save`.
2. **TOCTOU in `remove_figure`** — `get_figure_by_index(index)` and the `figure.index == 255` sentinel check were happening *before* the lock was acquired. Another thread invoking `load_figure` / `remove_figure` concurrently could mutate that figure between the check and the work. Moved both inside the locked section. No behavior change when `lock=false`; when `lock=true`, the early-return path now correctly holds the lock during the check.

## Test plan

- [ ] Builds locally (I don't have a build environment in this session — please confirm before merging)
- [ ] No behavior change for the common `lock=false` path
- [ ] Sanity-check that the `lock=true` callers don't expect to observe an unlocked state during the early return

## AI disclosure

Per the project's AI use policy in `README.md`: this change was drafted with Claude Code's assistance. Initial exploration was done by an AI agent; the change was reviewed and applied by hand after rejecting four other agent suggestions that turned out to be false positives (incorrect claims that `std::unique_lock` with `defer_lock` + later `.lock()` would leak the mutex — it does not). The committed change is small, mechanical, and follows a pattern already present in the codebase. It has **not** been built or runtime-tested in this session — please verify locally before merging.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EP55YiPqrrmsShSzn85dP8)_