### PR TITLE
Hardening round 2026-05-25: savestate, sys_*, cellSync, audio, RSX, Cell HLE, PPU

### DIFF
--- a/Utilities/Config.cpp
+++ b/Utilities/Config.cpp
@@ -96,7 +96,7 @@ bool try_to_int64(s64* out, std::string_view value, s64 min, s64 max, std::strin
 		start += 1;
 	}
 
-	if (start[0] == '0' && value.size() >= 2 && (start[1] == 'x' || start[1] == 'X'))
+	if (start < end && start[0] == '0' && end - start >= 2 && (start[1] == 'x' || start[1] == 'X'))
 	{
 		// Limited hex support
 		base = 16;

--- a/Utilities/Thread.cpp
+++ b/Utilities/Thread.cpp
@@ -2664,7 +2664,8 @@ void thread_ctrl::wait_until(u64* wait_time, u64 add_time, u64 min_wait, bool up
 	{
 		if (update_to_current_time)
 		{
-			*wait_time = current_time + (add_time - (current_time - *wait_time) % add_time);
+			// Guard against divide-by-zero when add_time defaulted to 0
+			*wait_time = add_time ? current_time + (add_time - (current_time - *wait_time) % add_time) : current_time;
 		}
 		else if (!min_wait)
 		{

--- a/Utilities/bin_patch.cpp
+++ b/Utilities/bin_patch.cpp
@@ -1280,9 +1280,9 @@ static usz apply_modification(std::vector<u32>& applied, patch_engine::patch_inf
 			if (func_name.starts_with("0x"sv))
 			{
 				// Raw hexadecimal-formatted FNID (real function name cannot contain a digit at the start, derived from C/CPP which were used in PS3 development)
-				const auto result = std::from_chars(func_name.data() + 2, func_name.data() + func_name.size() - 2, id, 16);
+				const auto result = std::from_chars(func_name.data() + 2, func_name.data() + func_name.size(), id, 16);
 
-				if (result.ec != std::errc() || str.data() + sep_pos != result.ptr)
+				if (result.ec != std::errc() || result.ptr != func_name.data() + func_name.size())
 				{
 					continue;
 				}

--- a/Utilities/geometry.h
+++ b/Utilities/geometry.h
@@ -173,23 +173,23 @@ struct position1_base
 	}
 
 	template<typename RhsT>
-	position1_base& operator *=(RhsT rhs) const
+	position1_base& operator *=(RhsT rhs)
 	{
 		x *= rhs;
 		return *this;
 	}
-	position1_base& operator *=(const position1_base& rhs) const
+	position1_base& operator *=(const position1_base& rhs)
 	{
 		x *= rhs.x;
 		return *this;
 	}
 	template<typename RhsT>
-	position1_base& operator /=(RhsT rhs) const
+	position1_base& operator /=(RhsT rhs)
 	{
 		x /= rhs;
 		return *this;
 	}
-	position1_base& operator /=(const position1_base& rhs) const
+	position1_base& operator /=(const position1_base& rhs)
 	{
 		x /= rhs.x;
 		return *this;

--- a/rpcs3/Crypto/unedat.cpp
+++ b/rpcs3/Crypto/unedat.cpp
@@ -859,6 +859,13 @@ bool EDATADecrypter::ReadHeader()
 	//	return false;
 	//}
 
+	// Reject malformed EDAT headers before any divide-by-zero on block_size
+	if (edatHeader.block_size <= 0 || edatHeader.block_size > 0x40'0000)
+	{
+		edat_log.error("NPDRM EDAT header has invalid block_size 0x%x", edatHeader.block_size);
+		return false;
+	}
+
 	file_size = edatHeader.file_size;
 	total_blocks = ::narrow<u32>(utils::aligned_div(edatHeader.file_size, edatHeader.block_size));
 

--- a/rpcs3/Crypto/unself.cpp
+++ b/rpcs3/Crypto/unself.cpp
@@ -677,6 +677,14 @@ bool SCEDecrypter::LoadMetadata(const u8 erk[32], const u8 riv[16])
 	// Load the metadata header.
 	meta_hdr.Load(metadata_headers.get());
 
+	// Validate that the metadata section headers and data keys fit in metadata_headers.
+	if (u64{meta_hdr.section_count} * sizeof(MetadataSectionHeader) + u64{meta_hdr.key_count} * 0x10 + sizeof(meta_hdr) > metadata_headers_size)
+	{
+		self_log.error("Invalid SCE metadata header (section_count=0x%x, key_count=0x%x, metadata_headers_size=0x%llx)",
+			meta_hdr.section_count, meta_hdr.key_count, metadata_headers_size);
+		return false;
+	}
+
 	// Load the metadata section headers.
 	meta_shdr.clear();
 	for (unsigned int i = 0; i < meta_hdr.section_count; i++)
@@ -1198,7 +1206,7 @@ bool SELFDecrypter::DecryptData()
 	{
 		if (meta_shdr[i].encrypted == 3)
 		{
-			if ((meta_shdr[i].key_idx <= meta_hdr.key_count - 1) && (meta_shdr[i].iv_idx <= meta_hdr.key_count))
+			if ((meta_shdr[i].key_idx < meta_hdr.key_count) && (meta_shdr[i].iv_idx < meta_hdr.key_count))
 				data_buf_length += ::narrow<u32>(meta_shdr[i].data_size);
 		}
 	}
@@ -1221,7 +1229,7 @@ bool SELFDecrypter::DecryptData()
 		if (meta_shdr[i].encrypted == 3)
 		{
 			// Make sure the key and iv are not out of boundaries.
-			if((meta_shdr[i].key_idx <= meta_hdr.key_count - 1) && (meta_shdr[i].iv_idx <= meta_hdr.key_count))
+			if((meta_shdr[i].key_idx < meta_hdr.key_count) && (meta_shdr[i].iv_idx < meta_hdr.key_count))
 			{
 				// Get the key and iv from the previously stored key buffer.
 				memcpy(data_key, data_keys.get() + meta_shdr[i].key_idx * 0x10, 0x10);

--- a/rpcs3/Emu/Audio/Cubeb/cubeb_enumerator.cpp
+++ b/rpcs3/Emu/Audio/Cubeb/cubeb_enumerator.cpp
@@ -77,6 +77,15 @@ std::vector<audio_device_enumerator::audio_device> cubeb_enumerator::get_output_
 			continue;
 		}
 
+		// cubeb_device_info::device_id / friendly_name are `const char*` that
+		// backends may leave null. Constructing std::string from a null pointer
+		// is UB, so skip any device without a usable id or name.
+		if (!dev_info.device_id || !dev_info.friendly_name)
+		{
+			cubeb_dev_enum.warning("Skipping device with null id or name");
+			continue;
+		}
+
 		audio_device dev =
 		{
 			.id = std::string{dev_info.device_id},

--- a/rpcs3/Emu/Audio/XAudio2/xaudio2_enumerator.cpp
+++ b/rpcs3/Emu/Audio/XAudio2/xaudio2_enumerator.cpp
@@ -70,10 +70,12 @@ std::vector<audio_device_enumerator::audio_device> xaudio2_enumerator::get_outpu
 			continue;
 		}
 
-		if (std::wstring_view{id}.empty())
+		// GetId can theoretically succeed with a null/empty id; constructing
+		// std::wstring_view{nullptr} is UB so check the pointer explicitly first.
+		if (!id || !*id)
 		{
 			xaudio_dev_enum.error("Empty device id - skipping");
-			CoTaskMemFree(id);
+			if (id) CoTaskMemFree(id);
 			continue;
 		}
 

--- a/rpcs3/Emu/Cell/Modules/cellAudio.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellAudio.cpp
@@ -398,7 +398,15 @@ cell_audio_thread::cell_audio_thread(utils::serial& ar)
 
 	ar(key_count, event_period);
 
-	keys.resize(ar);
+	// Reject corrupt/malicious savestates before they trigger a huge allocation
+	// in keys.resize(). MAX_AUDIO_EVENT_QUEUES is the cap enforced by
+	// cellAudioSetNotifyEventQueue at runtime.
+	const usz key_cnt = ar;
+	if (key_cnt > MAX_AUDIO_EVENT_QUEUES)
+	{
+		fmt::throw_exception("Invalid audio keys count in savestate: %u (max %u)", key_cnt, static_cast<u32>(MAX_AUDIO_EVENT_QUEUES));
+	}
+	keys.resize(key_cnt);
 
 	for (key_info& k : keys)
 	{
@@ -407,6 +415,49 @@ cell_audio_thread::cell_audio_thread(utils::serial& ar)
 	}
 
 	ar(ports);
+
+	// audio_port has ENABLE_BITWISE_SERIALIZATION, so the deserializer just
+	// memcpy'd the savestate bytes over each port. Validate every guest-
+	// influenced field that downstream code (position(), tag(), mix(), etc.)
+	// treats as a trusted invariant -- num_blocks==0 would div-by-zero in
+	// audio_port::position, out-of-range channel counts mis-tag buffers,
+	// and a stale prev_touched_tag_nr indexes last_tag_value[] out of bounds.
+	for (const audio_port& port : ports)
+	{
+		// State must be a valid enumerator regardless of whether the port is opened.
+		const audio_port_state st = port.state.load();
+		if (st != audio_port_state::closed && st != audio_port_state::opened && st != audio_port_state::started)
+		{
+			fmt::throw_exception("Invalid audio port state in savestate: %u", static_cast<u32>(st));
+		}
+
+		// Closed ports are zero-initialized so skip per-field range checks for them.
+		if (st == audio_port_state::closed)
+		{
+			continue;
+		}
+
+		if (port.num_channels != CELL_AUDIO_PORT_2CH && port.num_channels != CELL_AUDIO_PORT_8CH)
+		{
+			fmt::throw_exception("Invalid audio port num_channels in savestate: %u", port.num_channels);
+		}
+
+		if (port.num_blocks != 2 && port.num_blocks != 4 && port.num_blocks != CELL_AUDIO_BLOCK_8
+			&& port.num_blocks != CELL_AUDIO_BLOCK_16 && port.num_blocks != CELL_AUDIO_BLOCK_32)
+		{
+			fmt::throw_exception("Invalid audio port num_blocks in savestate: %u", port.num_blocks);
+		}
+
+		if (port.cur_pos >= port.num_blocks)
+		{
+			fmt::throw_exception("Invalid audio port cur_pos in savestate: %u (num_blocks=%u)", port.cur_pos, port.num_blocks);
+		}
+
+		if (port.prev_touched_tag_nr != umax && port.prev_touched_tag_nr >= PORT_BUFFER_TAG_COUNT)
+		{
+			fmt::throw_exception("Invalid audio port prev_touched_tag_nr in savestate: %u", port.prev_touched_tag_nr);
+		}
+	}
 }
 
 void cell_audio_thread::save(utils::serial& ar)

--- a/rpcs3/Emu/Cell/Modules/cellAudioOut.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellAudioOut.cpp
@@ -190,9 +190,69 @@ void audio_out_configuration::save(utils::serial& ar)
 {
 	GET_OR_USE_SERIALIZATION_VERSION(ar.is_writing(), cellAudioOut);
 
+	// The CellAudioOutDeviceInfo::availableModes[] guest-visible array is fixed
+	// at 16 entries (see cellAudioOutGetDeviceInfo ensure(<=16)). A crafted
+	// savestate could otherwise drive a multi-GB std::vector allocation here.
+	constexpr usz max_sound_modes = 16;
+
+	const auto valid_channel = [](u8 ch)
+	{
+		return ch == CELL_AUDIO_OUT_CHNUM_2 || ch == CELL_AUDIO_OUT_CHNUM_6 || ch == CELL_AUDIO_OUT_CHNUM_8;
+	};
+	const auto valid_type = [](u8 type)
+	{
+		return type == CELL_AUDIO_OUT_CODING_TYPE_LPCM
+			|| type == CELL_AUDIO_OUT_CODING_TYPE_AC3
+			|| type == CELL_AUDIO_OUT_CODING_TYPE_DTS;
+	};
+	const auto valid_fs = [](u8 fs)
+	{
+		return fs == CELL_AUDIO_OUT_FS_32KHZ
+			|| fs == CELL_AUDIO_OUT_FS_44KHZ
+			|| fs == CELL_AUDIO_OUT_FS_48KHZ
+			|| fs == CELL_AUDIO_OUT_FS_88KHZ
+			|| fs == CELL_AUDIO_OUT_FS_96KHZ
+			|| fs == CELL_AUDIO_OUT_FS_176KHZ
+			|| fs == CELL_AUDIO_OUT_FS_192KHZ;
+	};
+
 	for (auto& state : out)
 	{
-		ar(state.state, state.channels, state.encoder, state.downmixer, state.copy_control, state.sound_modes, state.sound_mode);
+		if (ar.is_writing())
+		{
+			ar(state.state, state.channels, state.encoder, state.downmixer, state.copy_control, state.sound_modes, state.sound_mode);
+		}
+		else
+		{
+			ar(state.state, state.channels, state.encoder, state.downmixer, state.copy_control);
+
+			// Read the sound_modes vector size first (VLE-encoded by the vector
+			// serializer), validate it, then deserialize entries so a crafted
+			// savestate cannot drive a runaway allocation here.
+			state.sound_modes.clear();
+			usz mode_cnt = 0;
+			ensure(ar.deserialize_vle(mode_cnt));
+			if (mode_cnt > max_sound_modes)
+			{
+				fmt::throw_exception("Invalid cellAudioOut sound_modes count in savestate: %u (max %u)", mode_cnt, max_sound_modes);
+			}
+			state.sound_modes.resize(mode_cnt);
+			for (CellAudioOutSoundMode& mode : state.sound_modes)
+			{
+				ar(mode);
+				if (!valid_channel(mode.channel) || !valid_type(mode.type) || !valid_fs(mode.fs))
+				{
+					fmt::throw_exception("Invalid cellAudioOut sound_mode in savestate: channel=%u type=%u fs=%u", mode.channel, mode.type, mode.fs);
+				}
+			}
+
+			ar(state.sound_mode);
+			if (!valid_channel(state.sound_mode.channel) || !valid_type(state.sound_mode.type) || !valid_fs(state.sound_mode.fs))
+			{
+				fmt::throw_exception("Invalid cellAudioOut active sound_mode in savestate: channel=%u type=%u fs=%u",
+					state.sound_mode.channel, state.sound_mode.type, state.sound_mode.fs);
+			}
+		}
 	}
 }
 

--- a/rpcs3/Emu/Cell/Modules/cellGame.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellGame.cpp
@@ -1831,7 +1831,10 @@ error_code cellGameThemeInstallFromBuffer(ppu_thread& ppu, u32 fileSize, u32 buf
 		return CELL_GAME_ERROR_PARAM;
 	}
 
-	const std::string hash = sha256_get_hash(reinterpret_cast<char*>(buf.get_ptr()), fileSize, true);
+	// Bound the hash input to the actual buffer contents to avoid out-of-bounds reads when a callback is supplied
+	// and fileSize exceeds bufSize. The earlier guard only rejects oversized fileSize when no callback is provided.
+	const u32 hash_size = std::min<u32>(fileSize, bufSize);
+	const std::string hash = sha256_get_hash(reinterpret_cast<char*>(buf.get_ptr()), hash_size, true);
 	const std::string dst_path = vfs::get(fmt::format("/dev_hdd0/theme/%s_%s.p3t", Emu.GetTitleID(), hash)); // TODO: this is renamed with some scheme
 
 	if (fs::file theme = fs::file(dst_path, fs::write_new + fs::isfile)) // TODO: new file is write protected

--- a/rpcs3/Emu/Cell/Modules/cellGcmSys.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellGcmSys.cpp
@@ -610,7 +610,8 @@ ret_type gcmSetPrepareFlip(ppu_thread& ppu, vm::ptr<CellGcmContextData> ctxt, u3
 		return CELL_GCM_ERROR_FAILURE;
 	}
 
-	if (!old_api && ctxt->current + 2 >= ctxt->end)
+	// Compare in u64 to avoid 32-bit wraparound when current is near the end of the address space.
+	if (!old_api && static_cast<u64>(ctxt->current.addr()) + 8 > static_cast<u64>(ctxt->end.addr()))
 	{
 		if (s32 res = ctxt->callback(ppu, ctxt, 8 /* ??? */))
 		{
@@ -724,7 +725,8 @@ void cellGcmSetUserCommand(ppu_thread& ppu, vm::ptr<CellGcmContextData> ctxt, u3
 {
 	cellGcmSys.trace("cellGcmSetUserCommand(ctxt=*0x%x, cause=0x%x)", ctxt, cause);
 
-	if (ctxt->current + 2 >= ctxt->end)
+	// Compare in u64 to avoid 32-bit wraparound when current is near the end of the address space.
+	if (static_cast<u64>(ctxt->current.addr()) + 8 > static_cast<u64>(ctxt->end.addr()))
 	{
 		if (s32 res = ctxt->callback(ppu, ctxt, 8 /* ??? */))
 		{
@@ -750,7 +752,8 @@ void cellGcmSetWaitFlip(ppu_thread& ppu, vm::ptr<CellGcmContextData> ctxt)
 {
 	cellGcmSys.trace("cellGcmSetWaitFlip(ctxt=*0x%x)", ctxt);
 
-	if (ctxt->current + 2 >= ctxt->end)
+	// Compare in u64 to avoid 32-bit wraparound when current is near the end of the address space.
+	if (static_cast<u64>(ctxt->current.addr()) + 8 > static_cast<u64>(ctxt->end.addr()))
 	{
 		if (s32 res = ctxt->callback(ppu, ctxt, 8 /* ??? */))
 		{
@@ -1142,6 +1145,12 @@ error_code cellGcmMapMainMemory(ppu_thread& ppu, u32 ea, u32 size, vm::ptr<u32> 
 	// Use the offset table to find the next free io address
 	for (u32 io = 0, end = (rsx::get_current_renderer()->main_mem_size - gcm_cfg.reserved_size) >> 20, unmap_count = 1; io < end; unmap_count++)
 	{
+		// Stop scanning before the trailing index escapes the eaAddress[0x200] table bounds.
+		if (io + unmap_count > end)
+		{
+			break;
+		}
+
 		if (gcm_cfg.offsetTable.eaAddress[io + unmap_count - 1] > 0xBFF)
 		{
 			if (unmap_count >= (size >> 20))

--- a/rpcs3/Emu/Cell/Modules/cellGcmSys.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellGcmSys.cpp
@@ -252,6 +252,11 @@ u32 cellGcmGetReportDataLocation(ppu_thread& ppu, u32 index, u32 location)
 	cellGcmSys.warning("cellGcmGetReportDataLocation(index=%d, location=%d)", index, location);
 
 	vm::ptr<CellGcmReportData> report = cellGcmGetReportDataAddressLocation(ppu, index, location);
+	if (!report)
+	{
+		// cellGcmGetReportDataAddressLocation returns vm::null on bad index.
+		return 0;
+	}
 	return report->value;
 }
 
@@ -260,6 +265,10 @@ u64 cellGcmGetTimeStampLocation(ppu_thread& ppu, u32 index, u32 location)
 	cellGcmSys.trace("cellGcmGetTimeStampLocation(index=%d, location=%d)", index, location);
 
 	vm::ptr<CellGcmReportData> report = cellGcmGetReportDataAddressLocation(ppu, index, location);
+	if (!report)
+	{
+		return 0;
+	}
 
 	// Timestamp reports don't need host GPU access and are much faster to emulate
 	return vm::get_super_ptr<CellGcmReportData>(report.addr())->timer;

--- a/rpcs3/Emu/Cell/Modules/cellHttpUtil.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellHttpUtil.cpp
@@ -52,6 +52,14 @@ error_code cellHttpUtilParseUri(vm::ptr<CellHttpUri> uri, vm::cptr<char> str, vm
 		{
 			return CELL_HTTP_UTIL_ERROR_NO_BUFFER;
 		}
+
+		// Populate mode (uri != null) requires a pool buffer to write into.
+		// The original guard only short-circuited when both pool and uri were null AND required was null,
+		// leaving a path where uri != null but pool == null would dereference null below in the memcpy calls.
+		if (!pool && uri)
+		{
+			return CELL_HTTP_UTIL_ERROR_NO_BUFFER;
+		}
 	}
 
 	LUrlParser::clParseURL URL = LUrlParser::clParseURL::ParseURL(str.get_ptr());

--- a/rpcs3/Emu/Cell/Modules/cellRtc.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellRtc.cpp
@@ -671,9 +671,17 @@ error_code cellRtcParseDateTime(ppu_thread& ppu, vm::ptr<CellRtcTick> pUtc, vm::
 
 	u32 pos = 0;
 
-	while (std::isblank(pszDateTime[pos]))
+	// Cap the leading-whitespace scan so a guest-supplied string of all blanks can't run away.
+	constexpr u32 max_parse_len = 64;
+
+	while (pos < max_parse_len && std::isblank(pszDateTime[pos]))
 	{
 		pos++;
+	}
+
+	if (pos >= max_parse_len)
+	{
+		return { CELL_RTC_ERROR_BAD_PARSE, "cellRtcParseDateTime(): only blanks within first %u bytes", max_parse_len };
 	}
 
 	if (std::isdigit(pszDateTime[pos]) &&
@@ -696,10 +704,15 @@ error_code cellRtcParseDateTime(ppu_thread& ppu, vm::ptr<CellRtcTick> pUtc, vm::
 		pos++;
 	}
 
-	// Skip spaces and tabs
-	while (std::isblank(pszDateTime[pos]))
+	// Skip spaces and tabs (bounded to prevent runaway on guest input)
+	while (pos < max_parse_len && std::isblank(pszDateTime[pos]))
 	{
 		pos++;
+	}
+
+	if (pos >= max_parse_len)
+	{
+		return { CELL_RTC_ERROR_BAD_PARSE, "cellRtcParseDateTime(): too many blanks after weekday" };
 	}
 
 	// Month: at least the first three letters
@@ -923,7 +936,10 @@ error_code cellRtcParseRfc3339(ppu_thread& ppu, vm::ptr<CellRtcTick> pUtc, vm::c
 	{
 		u32 mul = 100000;
 
-		for (char c = pszDateTime[++pos]; std::isdigit(c); c = pszDateTime[++pos])
+		// Cap the fractional-seconds scan so a guest-supplied digit run can't iterate unboundedly.
+		constexpr u32 max_rfc3339_len = 64;
+
+		for (char c = pszDateTime[++pos]; pos < max_rfc3339_len && std::isdigit(c); c = pszDateTime[++pos])
 		{
 			date_time->microsecond += digit(c) * mul;
 			mul /= 10;
@@ -1091,6 +1107,13 @@ error_code cellRtcSetTick(ppu_thread& ppu, vm::ptr<CellRtcDateTime> pTime, vm::c
 	if (sys_memory_get_page_attribute(ppu, pTick.addr(), page_attr) != CELL_OK)
 	{
 		return CELL_RTC_ERROR_INVALID_POINTER;
+	}
+
+	// Reject ticks outside the representable range; tick_to_date_time() will throw via narrow<u16>
+	// when the date components overflow (e.g. month_approx underflow for very large ticks).
+	if (pTick->tick > RTC_SYSTEM_TIME_MAX)
+	{
+		return CELL_RTC_ERROR_INVALID_ARG;
 	}
 
 	*pTime = tick_to_date_time(pTick->tick);
@@ -1262,11 +1285,22 @@ error_code cellRtcTickAddMonths(ppu_thread& ppu, vm::ptr<CellRtcTick> pTick0, vm
 	}
 
 	vm::var<CellRtcDateTime> date_time;
-	cellRtcSetTick(ppu, date_time, pTick1);
+	if (error_code err = cellRtcSetTick(ppu, date_time, pTick1))
+	{
+		return err;
+	}
 
-	const s32 total_months = date_time->year * 12 + date_time->month + iAdd - 1;
-	const u16 new_year = total_months / 12;
-	const u16 new_month = total_months - new_year * 12 + 1;
+	// Promote to s64 to avoid overflow from large iAdd values combined with year * 12.
+	const s64 total_months = s64{date_time->year} * 12 + s64{date_time->month} + s64{iAdd} - 1;
+
+	// Validate the result is within u16 year range before narrowing.
+	if (total_months < 0 || total_months / 12 > 0xFFFF)
+	{
+		return CELL_RTC_ERROR_INVALID_ARG;
+	}
+
+	const u16 new_year = static_cast<u16>(total_months / 12);
+	const u16 new_month = static_cast<u16>(total_months - s64{new_year} * 12 + 1);
 
 	s32 month_days;
 

--- a/rpcs3/Emu/Cell/Modules/cellSpurs.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellSpurs.cpp
@@ -2002,7 +2002,10 @@ s32 cellSpursGetInfo(vm::ptr<CellSpurs> spurs, vm::ptr<CellSpursInfo> info)
 	info->traceBuffer = vm::addr_t{trace_addr & ~3};
 	info->traceMode = trace_addr & 3;
 
-	const u8 name_size = spurs->prefixSize;
+	// Clamp guest-mutable prefixSize against the bound enforced by cellSpursInitializeWithAttribute2.
+	// namePrefix is a fixed 16-byte field and the trailing NUL write at [name_size] must stay in-bounds.
+	static_assert(sizeof(info->namePrefix) > CELL_SPURS_NAME_MAX_LENGTH, "namePrefix must hold prefix + NUL");
+	const u8 name_size = std::min<u8>(spurs->prefixSize, CELL_SPURS_NAME_MAX_LENGTH);
 	std::memcpy(&info->namePrefix, spurs->prefix, name_size);
 	info->namePrefix[name_size] = '\0';
 	info->namePrefixLength = name_size;

--- a/rpcs3/Emu/Cell/Modules/cellSync.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellSync.cpp
@@ -305,8 +305,16 @@ error_code cellSyncRwmRead(ppu_thread& ppu, vm::ptr<CellSyncRwm> rwm, vm::ptr<vo
 		}
 	}
 
+	// Re-validate guest-mutable size against the bounds enforced by cellSyncRwmInitialize
+	const u32 rwm_size = rwm->size;
+	if (rwm_size == 0 || rwm_size > 0x4000) [[unlikely]]
+	{
+		rwm->ctrl.atomic_op(&CellSyncRwm::try_read_end);
+		return CELL_SYNC_ERROR_INVAL;
+	}
+
 	// copy data to buffer
-	std::memcpy(buffer.get_ptr(), rwm->buffer.get_ptr(), rwm->size);
+	std::memcpy(buffer.get_ptr(), rwm->buffer.get_ptr(), rwm_size);
 
 	// decrease `readers`, return error if already zero
 	if (!rwm->ctrl.atomic_op(&CellSyncRwm::try_read_end))
@@ -337,8 +345,16 @@ error_code cellSyncRwmTryRead(vm::ptr<CellSyncRwm> rwm, vm::ptr<void> buffer)
 		return not_an_error(CELL_SYNC_ERROR_BUSY);
 	}
 
+	// Re-validate guest-mutable size against the bounds enforced by cellSyncRwmInitialize
+	const u32 rwm_size = rwm->size;
+	if (rwm_size == 0 || rwm_size > 0x4000) [[unlikely]]
+	{
+		rwm->ctrl.atomic_op(&CellSyncRwm::try_read_end);
+		return CELL_SYNC_ERROR_INVAL;
+	}
+
 	// copy data to buffer
-	std::memcpy(buffer.get_ptr(), rwm->buffer.get_ptr(), rwm->size);
+	std::memcpy(buffer.get_ptr(), rwm->buffer.get_ptr(), rwm_size);
 
 	// decrease `readers`, return error if already zero
 	if (!rwm->ctrl.atomic_op(&CellSyncRwm::try_read_end))
@@ -381,8 +397,16 @@ error_code cellSyncRwmWrite(ppu_thread& ppu, vm::ptr<CellSyncRwm> rwm, vm::cptr<
 		}
 	}
 
+	// Re-validate guest-mutable size against the bounds enforced by cellSyncRwmInitialize
+	const u32 rwm_size = rwm->size;
+	if (rwm_size == 0 || rwm_size > 0x4000) [[unlikely]]
+	{
+		rwm->ctrl.exchange({ 0, 0 });
+		return CELL_SYNC_ERROR_INVAL;
+	}
+
 	// copy data from buffer
-	std::memcpy(rwm->buffer.get_ptr(), buffer.get_ptr(), rwm->size);
+	std::memcpy(rwm->buffer.get_ptr(), buffer.get_ptr(), rwm_size);
 
 	// sync and clear `readers` and `writers`
 	rwm->ctrl.exchange({ 0, 0 });
@@ -410,8 +434,16 @@ error_code cellSyncRwmTryWrite(vm::ptr<CellSyncRwm> rwm, vm::cptr<void> buffer)
 		return not_an_error(CELL_SYNC_ERROR_BUSY);
 	}
 
+	// Re-validate guest-mutable size against the bounds enforced by cellSyncRwmInitialize
+	const u32 rwm_size = rwm->size;
+	if (rwm_size == 0 || rwm_size > 0x4000) [[unlikely]]
+	{
+		rwm->ctrl.exchange({ 0, 0 });
+		return CELL_SYNC_ERROR_INVAL;
+	}
+
 	// copy data from buffer
-	std::memcpy(rwm->buffer.get_ptr(), buffer.get_ptr(), rwm->size);
+	std::memcpy(rwm->buffer.get_ptr(), buffer.get_ptr(), rwm_size);
 
 	// sync and clear `readers` and `writers`
 	rwm->ctrl.exchange({ 0, 0 });
@@ -438,7 +470,7 @@ error_code cellSyncQueueInitialize(vm::ptr<CellSyncQueue> queue, vm::ptr<u8> buf
 		return CELL_SYNC_ERROR_ALIGN;
 	}
 
-	if (!depth || size % 16) [[unlikely]]
+	if (!depth || size % 16 || size > 0x4000) [[unlikely]]
 	{
 		return CELL_SYNC_ERROR_INVAL;
 	}
@@ -470,6 +502,13 @@ error_code cellSyncQueuePush(ppu_thread& ppu, vm::ptr<CellSyncQueue> queue, vm::
 
 	const u32 depth = queue->check_depth();
 
+	// Re-validate guest-mutable size against the bounds enforced by cellSyncQueueInitialize
+	const u32 q_size = queue->size;
+	if (q_size == 0 || q_size > 0x4000 || q_size % 16) [[unlikely]]
+	{
+		return CELL_SYNC_ERROR_INVAL;
+	}
+
 	u32 position;
 
 	while (!queue->ctrl.atomic_op([&](CellSyncQueue::ctrl_t& ctrl)
@@ -484,7 +523,7 @@ error_code cellSyncQueuePush(ppu_thread& ppu, vm::ptr<CellSyncQueue> queue, vm::
 	}
 
 	// copy data from the buffer at the position
-	std::memcpy(&queue->buffer[position * queue->size], buffer.get_ptr(), queue->size);
+	std::memcpy(&queue->buffer[position * q_size], buffer.get_ptr(), q_size);
 
 	queue->ctrl.atomic_op(&CellSyncQueue::push_end);
 
@@ -507,6 +546,13 @@ error_code cellSyncQueueTryPush(vm::ptr<CellSyncQueue> queue, vm::cptr<void> buf
 
 	const u32 depth = queue->check_depth();
 
+	// Re-validate guest-mutable size against the bounds enforced by cellSyncQueueInitialize
+	const u32 q_size = queue->size;
+	if (q_size == 0 || q_size > 0x4000 || q_size % 16) [[unlikely]]
+	{
+		return CELL_SYNC_ERROR_INVAL;
+	}
+
 	u32 position;
 
 	while (!queue->ctrl.atomic_op([&](CellSyncQueue::ctrl_t& ctrl)
@@ -518,7 +564,7 @@ error_code cellSyncQueueTryPush(vm::ptr<CellSyncQueue> queue, vm::cptr<void> buf
 	}
 
 	// copy data from the buffer at the position
-	std::memcpy(&queue->buffer[position * queue->size], buffer.get_ptr(), queue->size);
+	std::memcpy(&queue->buffer[position * q_size], buffer.get_ptr(), q_size);
 
 	queue->ctrl.atomic_op(&CellSyncQueue::push_end);
 
@@ -541,6 +587,13 @@ error_code cellSyncQueuePop(ppu_thread& ppu, vm::ptr<CellSyncQueue> queue, vm::p
 
 	const u32 depth = queue->check_depth();
 
+	// Re-validate guest-mutable size against the bounds enforced by cellSyncQueueInitialize
+	const u32 q_size = queue->size;
+	if (q_size == 0 || q_size > 0x4000 || q_size % 16) [[unlikely]]
+	{
+		return CELL_SYNC_ERROR_INVAL;
+	}
+
 	u32 position;
 
 	while (!queue->ctrl.atomic_op([&](CellSyncQueue::ctrl_t& ctrl)
@@ -555,7 +608,7 @@ error_code cellSyncQueuePop(ppu_thread& ppu, vm::ptr<CellSyncQueue> queue, vm::p
 	}
 
 	// copy data at the position to the buffer
-	std::memcpy(buffer.get_ptr(), &queue->buffer[position % depth * queue->size], queue->size);
+	std::memcpy(buffer.get_ptr(), &queue->buffer[position % depth * q_size], q_size);
 
 	queue->ctrl.atomic_op(&CellSyncQueue::pop_end);
 
@@ -578,6 +631,13 @@ error_code cellSyncQueueTryPop(vm::ptr<CellSyncQueue> queue, vm::ptr<void> buffe
 
 	const u32 depth = queue->check_depth();
 
+	// Re-validate guest-mutable size against the bounds enforced by cellSyncQueueInitialize
+	const u32 q_size = queue->size;
+	if (q_size == 0 || q_size > 0x4000 || q_size % 16) [[unlikely]]
+	{
+		return CELL_SYNC_ERROR_INVAL;
+	}
+
 	u32 position;
 
 	while (!queue->ctrl.atomic_op([&](CellSyncQueue::ctrl_t& ctrl)
@@ -589,7 +649,7 @@ error_code cellSyncQueueTryPop(vm::ptr<CellSyncQueue> queue, vm::ptr<void> buffe
 	}
 
 	// copy data at the position to the buffer
-	std::memcpy(buffer.get_ptr(), &queue->buffer[position % depth * queue->size], queue->size);
+	std::memcpy(buffer.get_ptr(), &queue->buffer[position % depth * q_size], q_size);
 
 	queue->ctrl.atomic_op(&CellSyncQueue::pop_end);
 
@@ -612,6 +672,13 @@ error_code cellSyncQueuePeek(ppu_thread& ppu, vm::ptr<CellSyncQueue> queue, vm::
 
 	const u32 depth = queue->check_depth();
 
+	// Re-validate guest-mutable size against the bounds enforced by cellSyncQueueInitialize
+	const u32 q_size = queue->size;
+	if (q_size == 0 || q_size > 0x4000 || q_size % 16) [[unlikely]]
+	{
+		return CELL_SYNC_ERROR_INVAL;
+	}
+
 	u32 position;
 
 	while (!queue->ctrl.atomic_op([&](CellSyncQueue::ctrl_t& ctrl)
@@ -626,7 +693,7 @@ error_code cellSyncQueuePeek(ppu_thread& ppu, vm::ptr<CellSyncQueue> queue, vm::
 	}
 
 	// copy data at the position to the buffer
-	std::memcpy(buffer.get_ptr(), &queue->buffer[position % depth * queue->size], queue->size);
+	std::memcpy(buffer.get_ptr(), &queue->buffer[position % depth * q_size], q_size);
 
 	queue->ctrl.atomic_op(&CellSyncQueue::pop_end);
 
@@ -649,6 +716,13 @@ error_code cellSyncQueueTryPeek(vm::ptr<CellSyncQueue> queue, vm::ptr<void> buff
 
 	const u32 depth = queue->check_depth();
 
+	// Re-validate guest-mutable size against the bounds enforced by cellSyncQueueInitialize
+	const u32 q_size = queue->size;
+	if (q_size == 0 || q_size > 0x4000 || q_size % 16) [[unlikely]]
+	{
+		return CELL_SYNC_ERROR_INVAL;
+	}
+
 	u32 position;
 
 	while (!queue->ctrl.atomic_op([&](CellSyncQueue::ctrl_t& ctrl)
@@ -660,7 +734,7 @@ error_code cellSyncQueueTryPeek(vm::ptr<CellSyncQueue> queue, vm::ptr<void> buff
 	}
 
 	// copy data at the position to the buffer
-	std::memcpy(buffer.get_ptr(), &queue->buffer[position % depth * queue->size], queue->size);
+	std::memcpy(buffer.get_ptr(), &queue->buffer[position % depth * q_size], q_size);
 
 	queue->ctrl.atomic_op(&CellSyncQueue::pop_end);
 
@@ -1157,8 +1231,15 @@ error_code _cellSyncLFQueuePushBody(ppu_thread& ppu, vm::ptr<CellSyncLFQueue> qu
 	}
 
 	const s32 depth = queue->m_depth;
-	const s32 size = queue->m_size;
+	const u32 size = queue->m_size;
 	const s32 pos = *position;
+
+	// Re-validate guest-mutable size against the bounds enforced by cellSyncLFQueueInitialize
+	if (size == 0 || size > 0x4000) [[unlikely]]
+	{
+		return CELL_SYNC_ERROR_INVAL;
+	}
+
 	const u32 addr = vm::cast<u64>((queue->m_buffer.addr() & ~1ull) + size * (pos >= depth ? pos - depth : pos));
 	std::memcpy(vm::base(addr), buffer.get_ptr(), size);
 
@@ -1457,8 +1538,15 @@ error_code _cellSyncLFQueuePopBody(ppu_thread& ppu, vm::ptr<CellSyncLFQueue> que
 	}
 
 	const s32 depth = queue->m_depth;
-	const s32 size = queue->m_size;
+	const u32 size = queue->m_size;
 	const s32 pos = *position;
+
+	// Re-validate guest-mutable size against the bounds enforced by cellSyncLFQueueInitialize
+	if (size == 0 || size > 0x4000) [[unlikely]]
+	{
+		return CELL_SYNC_ERROR_INVAL;
+	}
+
 	const u32 addr = vm::cast<u64>((queue->m_buffer.addr() & ~1) + size * (pos >= depth ? pos - depth : pos));
 	std::memcpy(buffer.get_ptr(), vm::base(addr), size);
 

--- a/rpcs3/Emu/Cell/Modules/sceNpTrophy.cpp
+++ b/rpcs3/Emu/Cell/Modules/sceNpTrophy.cpp
@@ -474,6 +474,22 @@ error_code sceNpTrophyCreateContext(vm::ptr<u32> context, vm::cptr<SceNpCommunic
 		name_str = name_str.substr(0, pos);
 	}
 
+	// Reject names containing characters that would later flow into VFS paths (e.g. '/', '\\', '.').
+	// commId->data is 9 raw bytes from the caller; allow only [A-Za-z0-9_-] and require non-empty length.
+	if (name_str.empty())
+	{
+		return SCE_NP_TROPHY_ERROR_INVALID_NP_COMM_ID;
+	}
+
+	for (char c : name_str)
+	{
+		const bool valid = (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') || (c >= '0' && c <= '9') || c == '_' || c == '-';
+		if (!valid)
+		{
+			return SCE_NP_TROPHY_ERROR_INVALID_NP_COMM_ID;
+		}
+	}
+
 	const SceNpCommunicationSignature commSign_data = *commSign;
 
 	if (read_from_ptr<be_t<u32>>(commSign_data.data, 0) != NP_TROPHY_COMM_SIGN_MAGIC)

--- a/rpcs3/Emu/Cell/PPUAnalyser.cpp
+++ b/rpcs3/Emu/Cell/PPUAnalyser.cpp
@@ -1261,6 +1261,13 @@ bool ppu_module<lv2_obj>::analyse(u32 lib_toc, u32 entry, const u32 sec_end, con
 			}
 			else
 			{
+				// FDE: ensure at least 6 u32 words (0x18 bytes) are available before reading ptr[2..5]
+				if (_ptr + 6 > sec_end)
+				{
+					ppu_log.error(".eh_frame: [0x%x] FDE too small (truncated before required fields)", ptr);
+					break;
+				}
+
 				// Get associated CIE (currently unused)
 				const vm::cptr<u32> cie = vm::cast(_ptr.addr() - ptr[1] + 4);
 

--- a/rpcs3/Emu/Cell/PPUInterpreter.cpp
+++ b/rpcs3/Emu/Cell/PPUInterpreter.cpp
@@ -3094,7 +3094,8 @@ auto MULLI()
 		return ppu_exec_select<Flags...>::template select<>();
 
 	static const auto exec = [](ppu_thread& ppu, ppu_opcode_t op) {
-	ppu.gpr[op.rd] = static_cast<s64>(ppu.gpr[op.ra]) * op.simm16;
+	// Compute the product in u64 so signed overflow is well-defined (wrap)
+	ppu.gpr[op.rd] = static_cast<u64>(static_cast<s64>(ppu.gpr[op.ra])) * static_cast<u64>(static_cast<s64>(op.simm16));
 	};
 	RETURN_(ppu, op);
 }
@@ -4589,7 +4590,8 @@ auto MULLD()
 	static const auto exec = [](ppu_thread& ppu, ppu_opcode_t op) {
 	const s64 RA = ppu.gpr[op.ra];
 	const s64 RB = ppu.gpr[op.rb];
-	ppu.gpr[op.rd] = RA * RB;
+	// Compute low-64 bits in u64 so wraparound is well-defined
+	ppu.gpr[op.rd] = static_cast<u64>(RA) * static_cast<u64>(RB);
 	if (op.oe) [[unlikely]]
 	{
 		const s64 high = utils::mulh64(RA, RB);

--- a/rpcs3/Emu/Cell/PPUModule.cpp
+++ b/rpcs3/Emu/Cell/PPUModule.cpp
@@ -612,8 +612,19 @@ static void ppu_patch_refs(const ppu_module<lv2_obj>& _module, std::vector<ppu_r
 		be_t<u32> addend; // Note: Treating it as addend seems to be correct for now, but still unknown if theres more in this variable
 	};
 
+	// Hard cap on iterations: even an extremely large PRX would not legitimately have this many
+	// references chained together. Stops a malformed/malicious module from looping forever or
+	// walking far off the end of any segment.
+	constexpr usz max_ref_iterations = 0x100000;
+	usz iter_count = 0;
+
 	for (const ref_t* ref = &_module.get_ref<ref_t>(fref); ref->type; fref += sizeof(ref_t), ref = &_module.get_ref<ref_t>(fref))
 	{
+		if (++iter_count > max_ref_iterations)
+		{
+			fmt::throw_exception("ppu_patch_refs: reference chain exceeded iteration cap (%u) at fref=0x%x", max_ref_iterations, fref);
+		}
+
 		if (ref->addend) ppu_loader.warning("**** REF(%u): Addend value(0x%x, 0x%x)", ref->type, ref->addr, ref->addend);
 
 		const u32 raddr = ref->addr;
@@ -1733,7 +1744,11 @@ shared_ptr<lv2_prx> ppu_load_prx(const ppu_prx_object& elf, bool virtual_load, c
 				vm::bptr<void, u64> ptr;
 			};
 
-			for (uint i = 0; i + sizeof(ppu_prx_relocation_info) <= prog.p_filesz; i += sizeof(ppu_prx_relocation_info))
+			// Bound by both p_filesz and the actual buffer size; use usz so a >4 GiB p_filesz
+			// would not wrap a 32-bit counter and run off the buffer.
+			const usz reloc_limit = std::min<u64>(prog.p_filesz, prog.bin.size());
+
+			for (usz i = 0; i + sizeof(ppu_prx_relocation_info) <= reloc_limit; i += sizeof(ppu_prx_relocation_info))
 			{
 				const auto& rel = reinterpret_cast<const ppu_prx_relocation_info&>(prog.bin[i]);
 

--- a/rpcs3/Emu/Cell/PPUThread.cpp
+++ b/rpcs3/Emu/Cell/PPUThread.cpp
@@ -2524,11 +2524,24 @@ struct save_lv2_tag
 	atomic_t<bool> loaded = false;
 };
 
+// Validate ppu_join_status read from a savestate; coerce out-of-range values to joinable
+// (matches the save-side behavior at ppu_thread::save where >= max is rewritten to joinable).
+static ppu_join_status ppu_load_join_status(utils::serial& ar)
+{
+	const u32 raw = ar.pop<u32>();
+	if (raw >= static_cast<u32>(ppu_join_status::max))
+	{
+		ppu_log.error("ppu_thread savestate: invalid joiner value 0x%x, coercing to joinable", raw);
+		return ppu_join_status::joinable;
+	}
+	return static_cast<ppu_join_status>(raw);
+}
+
 ppu_thread::ppu_thread(utils::serial& ar)
 	: cpu_thread(idm::last_id()) // last_id() is showed to constructor on serialization
 	, stack_size(ar)
 	, stack_addr(ar)
-	, joiner(ar.pop<ppu_join_status>())
+	, joiner(ppu_load_join_status(ar))
 	, entry_func(std::bit_cast<ppu_func_opd_t, u64>(ar))
 	, is_interrupt_thread(ar)
 {
@@ -2696,6 +2709,10 @@ ppu_thread::ppu_thread(utils::serial& ar)
 	{
 		queue_intr_entry();
 		break;
+	}
+	default:
+	{
+		fmt::throw_exception("ppu_thread savestate: invalid status 0x%x", status);
 	}
 	}
 

--- a/rpcs3/Emu/Cell/SPUThread.cpp
+++ b/rpcs3/Emu/Cell/SPUThread.cpp
@@ -1801,6 +1801,17 @@ void spu_thread::serialize_common(utils::serial& ar)
 		, ch_out_mbox.data, ch_out_intr_mbox.data, snr_config, ch_snr1.data, ch_snr2.data, ch_events.raw().all, interrupts_enabled
 		, run_ctrl, exit_status.data, status_npc.raw().status, ch_dec_start_timestamp, ch_dec_value, is_dec_frozen);
 
+	if (!ar.is_writing())
+	{
+		// Reject corrupt/malicious savestates before they can scribble past
+		// the fixed-size mfc_queue / vals[] arrays or send the SPU dispatcher
+		// off into unmapped LS.
+		if (mfc_size > std::size(mfc_queue) || pc >= SPU_LS_SIZE || (pc & 3) != 0)
+		{
+			fmt::throw_exception("SPU savestate rejected: mfc_size=0x%x pc=0x%x", mfc_size, pc);
+		}
+	}
+
 	ar(std::span(mfc_queue, mfc_size));
 
 	u32 vals[4]{};
@@ -1813,6 +1824,10 @@ void spu_thread::serialize_common(utils::serial& ar)
 	else
 	{
 		const u8 count = ar;
+		if (count > std::size(vals))
+		{
+			fmt::throw_exception("SPU savestate rejected: ch_in_mbox count=%u exceeds capacity 4", count);
+		}
 		ar(std::span(vals, count));
 		ch_in_mbox.set_values(count, vals[0], vals[1], vals[2], vals[3]);
 	}

--- a/rpcs3/Emu/Cell/lv2/sys_event.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_event.cpp
@@ -641,6 +641,11 @@ error_code sys_event_port_create(cpu_thread& cpu, vm::ptr<u32> eport_id, s32 por
 
 	sys_event.warning("sys_event_port_create(eport_id=*0x%x, port_type=%d, name=0x%llx)", eport_id, port_type, name);
 
+	if (!eport_id)
+	{
+		return CELL_EFAULT;
+	}
+
 	if (port_type != SYS_EVENT_PORT_LOCAL && port_type != SYS_EVENT_PORT_IPC)
 	{
 		sys_event.error("sys_event_port_create(): unknown port type (%d)", port_type);

--- a/rpcs3/Emu/Cell/lv2/sys_fs.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_fs.cpp
@@ -1159,6 +1159,11 @@ error_code sys_fs_open(ppu_thread& ppu, vm::cptr<char> path, s32 flags, vm::ptr<
 
 	sys_fs.warning("sys_fs_open(path=%s, flags=%#o, fd=*0x%x, mode=%#o, arg=*0x%x, size=0x%llx)", path, flags, fd, mode, arg, size);
 
+	if (!fd)
+	{
+		return CELL_EFAULT;
+	}
+
 	const auto [path_error, vpath] = translate_to_str(path);
 
 	if (path_error)
@@ -1437,6 +1442,11 @@ error_code sys_fs_opendir(ppu_thread& ppu, vm::cptr<char> path, vm::ptr<u32> fd)
 	lv2_obj::sleep(ppu);
 
 	sys_fs.warning("sys_fs_opendir(path=%s, fd=*0x%x)", path, fd);
+
+	if (!fd)
+	{
+		return CELL_EFAULT;
+	}
 
 	const auto [path_error, vpath] = translate_to_str(path);
 
@@ -2347,6 +2357,15 @@ error_code sys_fs_fcntl(ppu_thread& ppu, u32 fd, u32 op, vm::ptr<void> _arg, u32
 
 		arg->out_code = CELL_OK;
 
+		// Cap guest-supplied sizes to sane maxima (real values are 0x29 for model, 0x15 for serial)
+		constexpr u32 max_model_size = 0x100;
+		constexpr u32 max_serial_size = 0x100;
+
+		if (arg->model_size > max_model_size || arg->serial_size > max_serial_size)
+		{
+			return CELL_EINVAL;
+		}
+
 		if (const auto size = arg->model_size; size > 0)
 			strcpy_trunc(std::span(arg->model.get_ptr(), size),
 				fmt::format("%-*s", size - 1, g_cfg.sys.hdd_model.to_string())); // Example: "TOSHIBA MK3265GSX H                     "
@@ -2618,6 +2637,15 @@ error_code sys_fs_fcntl(ppu_thread& ppu, u32 fd, u32 op, vm::ptr<void> _arg, u32
 		// NOTE: This function is actually capable of reading only one entry at a time
 		if (const u32 max = arg->max)
 		{
+			// Bound guest-supplied max against the size of an entry to prevent overflow,
+			// and verify the destination buffer range is actually writable guest memory
+			const u64 byte_size = static_cast<u64>(max) * arg->ptr.size();
+
+			if (byte_size > u32{umax} || !vm::check_addr(arg->ptr.addr(), vm::page_writable, static_cast<u32>(byte_size)))
+			{
+				return CELL_EFAULT;
+			}
+
 			const auto arg_ptr = +arg->ptr;
 
 			if (auto* info = directory->dir_read())
@@ -2869,6 +2897,11 @@ error_code sys_fs_fget_block_size(ppu_thread& ppu, u32 fd, vm::ptr<u64> sector_s
 
 	sys_fs.warning("sys_fs_fget_block_size(fd=%d, sector_size=*0x%x, block_size=*0x%x, arg4=*0x%x, out_flags=*0x%x)", fd, sector_size, block_size, arg4, out_flags);
 
+	if (!sector_size || !block_size || !arg4 || !out_flags)
+	{
+		return CELL_EFAULT;
+	}
+
 	const auto file = idm::get_unlocked<lv2_fs_object, lv2_file>(fd);
 
 	if (!file)
@@ -2892,6 +2925,11 @@ error_code sys_fs_get_block_size(ppu_thread& ppu, vm::cptr<char> path, vm::ptr<u
 	lv2_obj::sleep(ppu);
 
 	sys_fs.warning("sys_fs_get_block_size(path=%s, sector_size=*0x%x, block_size=*0x%x, arg4=*0x%x)", path, sector_size, block_size, arg4);
+
+	if (!sector_size || !block_size || !arg4)
+	{
+		return CELL_EFAULT;
+	}
 
 	const auto [path_error, vpath] = translate_to_str(path);
 
@@ -3137,7 +3175,7 @@ error_code sys_fs_disk_free(ppu_thread& ppu, vm::cptr<char> path, vm::ptr<u64> t
 
 	sys_fs.warning("sys_fs_disk_free(path=%s total_free=*0x%x avail_free=*0x%x)", path, total_free, avail_free);
 
-	if (!path)
+	if (!path || !total_free || !avail_free)
 		return CELL_EFAULT;
 
 	if (!path[0])
@@ -3214,6 +3252,12 @@ error_code sys_fs_utime(ppu_thread& ppu, vm::cptr<char> path, vm::cptr<CellFsUti
 	lv2_obj::sleep(ppu);
 
 	sys_fs.warning("sys_fs_utime(path=%s, timep=*0x%x)", path, timep);
+
+	if (!timep)
+	{
+		return CELL_EFAULT;
+	}
+
 	sys_fs.warning("** actime=%u, modtime=%u", timep->actime, timep->modtime);
 
 	const auto [path_error, vpath] = translate_to_str(path);

--- a/rpcs3/Emu/Cell/lv2/sys_fs.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_fs.cpp
@@ -852,7 +852,18 @@ error_code sys_fs_test(ppu_thread&, u32 arg1, u32 arg2, vm::ptr<u32> arg3, u32 a
 		return CELL_EBADF;
 	}
 
-	for (u32 i = 0; i < buf_size; i++)
+	// Bail out on the degenerate buf_size == 0 case: with u32 wraparound
+	// `buf[buf_size - 1]` would otherwise write at buf[0xFFFFFFFF].
+	if (!buf_size)
+	{
+		return CELL_OK;
+	}
+
+	// file->name is a fixed std::array<char, 0x420>; clamp the host-side read
+	// so guests can't drive a buf_size > 0x420 into an OOB read.
+	const u32 max_copy = std::min<u32>(buf_size, static_cast<u32>(file->name.size()));
+
+	for (u32 i = 0; i < max_copy; i++)
 	{
 		if (!(buf[i] = file->name[i]))
 		{
@@ -860,7 +871,7 @@ error_code sys_fs_test(ppu_thread&, u32 arg1, u32 arg2, vm::ptr<u32> arg3, u32 a
 		}
 	}
 
-	buf[buf_size - 1] = 0;
+	buf[max_copy - 1] = 0;
 	return CELL_OK;
 }
 

--- a/rpcs3/Emu/Cell/lv2/sys_lwcond.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_lwcond.cpp
@@ -31,6 +31,11 @@ error_code _sys_lwcond_create(ppu_thread& ppu, vm::ptr<u32> lwcond_id, u32 lwmut
 
 	sys_lwcond.trace(u8"_sys_lwcond_create(lwcond_id=*0x%x, lwmutex_id=0x%x, control=*0x%x, name=0x%llx (“%s”))", lwcond_id, lwmutex_id, control, name, lv2_obj::name_64{std::bit_cast<be_t<u64>>(name)});
 
+	if (!lwcond_id)
+	{
+		return CELL_EFAULT;
+	}
+
 	u32 protocol;
 
 	// Extract protocol from lwmutex

--- a/rpcs3/Emu/Cell/lv2/sys_lwmutex.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_lwmutex.cpp
@@ -29,6 +29,11 @@ error_code _sys_lwmutex_create(ppu_thread& ppu, vm::ptr<u32> lwmutex_id, u32 pro
 
 	sys_lwmutex.trace(u8"_sys_lwmutex_create(lwmutex_id=*0x%x, protocol=0x%x, control=*0x%x, has_name=0x%x, name=0x%llx (“%s”))", lwmutex_id, protocol, control, has_name, name, lv2_obj::name_64{std::bit_cast<be_t<u64>>(name)});
 
+	if (!lwmutex_id)
+	{
+		return CELL_EFAULT;
+	}
+
 	if (protocol != SYS_SYNC_FIFO && protocol != SYS_SYNC_RETRY && protocol != SYS_SYNC_PRIORITY)
 	{
 		sys_lwmutex.error("_sys_lwmutex_create(): unknown protocol (0x%x)", protocol);

--- a/rpcs3/Emu/Cell/lv2/sys_memory.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_memory.cpp
@@ -325,6 +325,11 @@ error_code sys_memory_get_user_memory_size(cpu_thread& cpu, vm::ptr<sys_memory_i
 {
 	cpu.state += cpu_flag::wait;
 
+	if (!mem_info)
+	{
+		return CELL_EFAULT;
+	}
+
 	// Get "default" memory container
 	auto& dct = g_fxo->get<lv2_memory_container>();
 
@@ -377,6 +382,11 @@ error_code sys_memory_container_create(cpu_thread& cpu, vm::ptr<u32> cid, u64 si
 	cpu.state += cpu_flag::wait;
 
 	sys_memory.warning("sys_memory_container_create(cid=*0x%x, size=0x%x)", cid, size);
+
+	if (!cid)
+	{
+		return CELL_EFAULT;
+	}
 
 	// Round down to 1 MB granularity
 	size &= ~0xfffff;

--- a/rpcs3/Emu/Cell/lv2/sys_mmapper.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_mmapper.cpp
@@ -51,7 +51,12 @@ lv2_memory::lv2_memory(utils::serial& ar)
 	{
 		if (addr)
 		{
-			return make_single_value(ensure(vm::get(vm::any, addr)->peek(addr).second));
+			const auto area = vm::get(vm::any, addr);
+			if (!area)
+			{
+				fmt::throw_exception("Invalid lv2_memory savestate: no vm area at addr=0x%x", addr);
+			}
+			return make_single_value(ensure(area->peek(addr).second));
 		}
 
 		return null_ptr;

--- a/rpcs3/Emu/Cell/lv2/sys_mmapper.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_mmapper.cpp
@@ -198,6 +198,13 @@ error_code sys_mmapper_allocate_shared_memory(ppu_thread& ppu, u64 ipc_key, u64 
 		return CELL_EALIGN;
 	}
 
+	// create_lv2_shm narrows size to u32; reject 4 GiB+ requests so an
+	// alignment-OK truncation to size=0 cannot create a bogus lv2_memory.
+	if (size > u32{umax})
+	{
+		return CELL_ENOMEM;
+	}
+
 	// Check page granularity
 	switch (flags & SYS_MEMORY_GRANULARITY_MASK)
 	{
@@ -248,6 +255,11 @@ error_code sys_mmapper_allocate_shared_memory_from_container(ppu_thread& ppu, u6
 	if (size == 0)
 	{
 		return CELL_EALIGN;
+	}
+
+	if (size > u32{umax})
+	{
+		return CELL_ENOMEM;
 	}
 
 	// Check page granularity.
@@ -304,6 +316,11 @@ error_code sys_mmapper_allocate_shared_memory_ext(ppu_thread& ppu, u64 ipc_key, 
 	if (size == 0)
 	{
 		return CELL_EALIGN;
+	}
+
+	if (size > u32{umax})
+	{
+		return CELL_ENOMEM;
 	}
 
 	switch (flags & SYS_MEMORY_GRANULARITY_MASK)
@@ -404,6 +421,11 @@ error_code sys_mmapper_allocate_shared_memory_from_container_ext(ppu_thread& ppu
 	if (size == 0)
 	{
 		return CELL_EALIGN;
+	}
+
+	if (size > u32{umax})
+	{
+		return CELL_ENOMEM;
 	}
 
 	switch (flags & SYS_MEMORY_PAGE_SIZE_MASK)
@@ -839,6 +861,13 @@ error_code sys_mmapper_enable_page_fault_notification(ppu_thread& ppu, u32 start
 	{
 		// Not enough system resources.
 		return CELL_EAGAIN;
+	}
+
+	if (res != CELL_OK)
+	{
+		// Any other error from port_create means *port_id is still 0;
+		// propagate the failure instead of inserting a bogus entry.
+		return res;
 	}
 
 	sys_event_port_connect_local(ppu, *port_id, event_queue_id);

--- a/rpcs3/Emu/Cell/lv2/sys_process.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_process.cpp
@@ -304,6 +304,11 @@ error_code sys_process_get_sdk_version(u32 pid, vm::ptr<s32> version)
 {
 	sys_process.warning("sys_process_get_sdk_version(pid=0x%x, version=*0x%x)", pid, version);
 
+	if (!version)
+	{
+		return CELL_EFAULT;
+	}
+
 	s32 sdk_ver;
 	const s32 ret = process_get_sdk_version(pid, sdk_ver);
 	if (ret != CELL_OK)

--- a/rpcs3/Emu/Cell/lv2/sys_prx.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_prx.cpp
@@ -439,6 +439,14 @@ error_code _sys_prx_load_module_on_memcontainer_by_fd(ppu_thread& ppu, s32 fd, u
 
 static error_code prx_load_module_list(ppu_thread& ppu, s32 count, vm::cpptr<char, u32, u64> path_list, u32 /*mem_ct*/, u64 flags, vm::ptr<sys_prx_load_module_option_t> pOpt, vm::ptr<u32> id_list)
 {
+	// Cap guest-supplied count and require a valid id_list; the failure
+	// rollback path memsets count*4 bytes through id_list, so an unbounded
+	// or NULL value lets the guest scribble far past its own buffer.
+	if (count <= 0 || count > 0x100 || !id_list || !path_list)
+	{
+		return CELL_EINVAL;
+	}
+
 	if (flags != 0)
 	{
 		if (flags & SYS_PRX_LOAD_MODULE_FLAGS_INVALIDMASK)
@@ -466,7 +474,7 @@ static error_code prx_load_module_list(ppu_thread& ppu, s32 count, vm::cpptr<cha
 				_sys_prx_unload_module(ppu, id_list[i], 0, vm::null);
 			}
 
-			// Fill with -1
+			// Fill with -1 (count is bounded above, safe to memset)
 			std::memset(id_list.get_ptr(), -1, count * sizeof(id_list[0]));
 			return result;
 		}

--- a/rpcs3/Emu/Cell/lv2/sys_prx.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_prx.cpp
@@ -1061,6 +1061,11 @@ error_code _sys_prx_get_module_info(ppu_thread& ppu, u32 id, u64 flags, vm::ptr<
 	pOpt->info->all_segments_num = ::size32(prx->segs);
 	if (pOpt->info->filename)
 	{
+		if (pOpt->info->filename_size > SYS_PRX_MODULE_FILENAME_SIZE)
+		{
+			return CELL_PRX_ERROR_INVAL;
+		}
+
 		std::span dst(pOpt->info->filename.get_ptr(), pOpt->info->filename_size);
 		strcpy_trunc(dst, vfs::retrieve(prx->path));
 	}

--- a/rpcs3/Emu/Cell/lv2/sys_spu.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_spu.cpp
@@ -512,6 +512,11 @@ error_code _sys_spu_image_get_information(ppu_thread& ppu, vm::ptr<sys_spu_image
 
 	sys_spu.warning("_sys_spu_image_get_information(img=*0x%x, entry_point=*0x%x, nsegs=*0x%x)", img, entry_point, nsegs);
 
+	if (!entry_point || !nsegs)
+	{
+		return CELL_EFAULT;
+	}
+
 	if (img->type != SYS_SPU_IMAGE_TYPE_KERNEL)
 	{
 		return CELL_EINVAL;
@@ -1768,6 +1773,11 @@ error_code sys_spu_thread_group_get_priority(ppu_thread& ppu, u32 id, vm::ptr<s3
 
 	sys_spu.trace("sys_spu_thread_group_get_priority(id=0x%x, priority=*0x%x)", id, priority);
 
+	if (!priority)
+	{
+		return CELL_EFAULT;
+	}
+
 	const auto group = idm::get_unlocked<lv2_spu_group>(id);
 
 	if (!group)
@@ -2510,6 +2520,11 @@ error_code sys_isolated_spu_create(ppu_thread& ppu, vm::ptr<u32> id, vm::ptr<voi
 	ppu.state += cpu_flag::wait;
 
 	sys_spu.todo("sys_isolated_spu_create(id=*0x%x, image=*0x%x, arg1=0x%llx, arg2=0x%llx, arg3=0x%llx, arg4=0x%llx)", id, image, arg1, arg2, arg3, arg4);
+
+	if (!id)
+	{
+		return CELL_EFAULT;
+	}
 
 	// TODO: More accurate SPU image memory size calculation
 	u32 max = image.addr() & -4096;

--- a/rpcs3/Emu/Cell/lv2/sys_timer.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_timer.cpp
@@ -174,6 +174,11 @@ error_code sys_timer_create(ppu_thread& ppu, vm::ptr<u32> timer_id)
 
 	sys_timer.warning("sys_timer_create(timer_id=*0x%x)", timer_id);
 
+	if (!timer_id)
+	{
+		return CELL_EFAULT;
+	}
+
 	if (auto ptr = idm::make_ptr<lv2_obj, lv2_timer>())
 	{
 		auto& thread = g_fxo->get<named_thread<lv2_timer_thread>>();

--- a/rpcs3/Emu/Cell/lv2/sys_vm.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_vm.cpp
@@ -401,6 +401,11 @@ error_code sys_vm_test(ppu_thread& ppu, u32 addr, u32 size, vm::ptr<u64> result)
 
 	sys_vm.warning("sys_vm_test(addr=0x%x, size=0x%x, result=*0x%x)", addr, size, result);
 
+	if (!result)
+	{
+		return CELL_EFAULT;
+	}
+
 	const auto block = idm::get_unlocked<sys_vm_t>(sys_vm_t::find_id(addr));
 
 	if (!block || u64{addr} + size > u64{block->addr} + block->size)
@@ -419,6 +424,11 @@ error_code sys_vm_get_statistics(ppu_thread& ppu, u32 addr, vm::ptr<sys_vm_stati
 	ppu.state += cpu_flag::wait;
 
 	sys_vm.warning("sys_vm_get_statistics(addr=0x%x, stat=*0x%x)", addr, stat);
+
+	if (!stat)
+	{
+		return CELL_EFAULT;
+	}
 
 	const auto block = idm::get_unlocked<sys_vm_t>(sys_vm_t::find_id(addr));
 

--- a/rpcs3/Emu/Io/GunCon3.cpp
+++ b/rpcs3/Emu/Io/GunCon3.cpp
@@ -286,9 +286,9 @@ void usb_device_guncon3::interrupt_transfer(u32 buf_size, u8* buf, u32 endpoint,
 			return;
 		}
 
-		// Expand 0..+wh to -32767..+32767
-		gc.gun_x = (mouse_data.x_pos * USHRT_MAX / mouse_data.x_max) - SHRT_MAX;
-		gc.gun_y = (mouse_data.y_pos * -USHRT_MAX / mouse_data.y_max) + SHRT_MAX;
+		// Expand 0..+wh to -32767..+32767 (force 64-bit math; x_pos*USHRT_MAX overflows s32 for high-DPI inputs)
+		gc.gun_x = static_cast<s32>(static_cast<s64>(mouse_data.x_pos) * USHRT_MAX / mouse_data.x_max - SHRT_MAX);
+		gc.gun_y = static_cast<s32>(static_cast<s64>(mouse_data.y_pos) * -USHRT_MAX / mouse_data.y_max + SHRT_MAX);
 	}
 
 	guncon3_encode(&gc, buf, m_key.data());

--- a/rpcs3/Emu/Io/LogitechG27.cpp
+++ b/rpcs3/Emu/Io/LogitechG27.cpp
@@ -1224,8 +1224,13 @@ void usb_device_logitech_g27::interrupt_transfer(u32 buf_size, u8* buf, u32 endp
 				// Change device mode
 				u8 cmd = buf[1];
 				u8 arg = buf[2];
-				if (buf[8] == 0xf8) // we have 2 commands back to back
+				if (buf_size > 8 && buf[8] == 0xf8) // we have 2 commands back to back
 				{
+					if (buf_size < 11)
+					{
+						logitech_g27_log.error("Truncated change-device-mode command (size %u)", buf_size);
+						return;
+					}
 					cmd = buf[9];
 					arg = buf[10];
 				}

--- a/rpcs3/Emu/Io/Skylander.cpp
+++ b/rpcs3/Emu/Io/Skylander.cpp
@@ -235,6 +235,12 @@ void usb_device_skylander::control_transfer(u8 bmRequestType, u8 bRequest, u16 w
 
 			std::array<u8, 32> q_result = {};
 
+			if (buf_size < 1)
+			{
+				// Guest sent a zero-length control transfer; nothing to dispatch on.
+				break;
+			}
+
 			switch (buf[0])
 			{
 			case 'A':

--- a/rpcs3/Emu/Io/usio.cpp
+++ b/rpcs3/Emu/Io/usio.cpp
@@ -524,7 +524,8 @@ void usb_device_usio::emulate_card_reader(std::vector<u8>& buf, u16 reg)
 		}
 		case 0xFB:
 		{
-			if (payload_length >= 5)
+			// Both the self-reported payload_length and the actual buffer size must cover up to payload[3].
+			if (payload_length >= 5 && buf.size() >= 6 + 5)
 			{
 				if (*reinterpret_cast<const le_t<u16>*>(&payload[0]) == 0x0140)
 				{

--- a/rpcs3/Emu/Memory/vm.cpp
+++ b/rpcs3/Emu/Memory/vm.cpp
@@ -1800,6 +1800,21 @@ namespace vm
 		, size(ar)
 		, flags(ar)
 	{
+		// Validate attacker-controlled header fields from the savestate before
+		// using them to drive host allocations / g_pages writes.
+		if (addr % 0x10000 != 0 || size == 0 || size % 0x10000 != 0 || u64{addr} + size > 0x1'0000'0000ull)
+		{
+			fmt::throw_exception("Invalid block_t in savestate: addr=0x%x size=0x%x flags=0x%x", addr, size, flags);
+		}
+
+		// Reject unknown / disallowed flag bits. process_block_flags() is idempotent on a
+		// well-formed flag set, so any change indicates the input was malformed.
+		const u64 allowed_flags_mask = u64{page_size_mask} | stack_guarded | preallocated | bf0_mask;
+		if ((flags & ~allowed_flags_mask) != 0 || process_block_flags(flags) != flags)
+		{
+			fmt::throw_exception("Invalid block_t in savestate: addr=0x%x size=0x%x flags=0x%x", addr, size, flags);
+		}
+
 		if (flags & preallocated)
 		{
 			m_common = std::make_shared<utils::shm>(size, fmt::format("_block_x%08x", addr));
@@ -1808,6 +1823,11 @@ namespace vm
 		}
 
 		std::shared_ptr<utils::shm> null_shm;
+
+		// Cap the loop to one iteration per 4 KiB page in this block so a malformed
+		// savestate can't drive an unbounded loop.
+		const u64 max_iterations = u64{this->size} / 4096;
+		u64 iteration = 0;
 
 		while (true)
 		{
@@ -1819,8 +1839,22 @@ namespace vm
 				break;
 			}
 
+			if (++iteration > max_iterations)
+			{
+				fmt::throw_exception("Too many page entries in block_t savestate: addr=0x%x size=0x%x", this->addr, this->size);
+			}
+
 			const u32 addr0 = ar;
 			const u32 size0 = ar;
+
+			// Validate the per-page range before touching g_pages / try_alloc.
+			if (addr0 % 0x10000 != 0 || size0 == 0 || size0 % 0x10000 != 0
+				|| u64{addr0} + size0 > 0x1'0000'0000ull
+				|| u64{addr0} < u64{this->addr}
+				|| u64{addr0} + size0 > u64{this->addr} + this->size)
+			{
+				fmt::throw_exception("Invalid page range in block_t savestate: addr=0x%x size=0x%x (block addr=0x%x size=0x%x)", addr0, size0, this->addr, this->size);
+			}
 
 			u64 pflags = 0;
 
@@ -1850,12 +1884,31 @@ namespace vm
 
 			// Map the memory through the same method as alloc() and falloc()
 			// Copy the shared handle unconditionally
-			ensure(try_alloc(addr0, pflags, size0, ::as_rvalue(flags & preallocated ? null_shm : shared[ar.pop<usz>()])));
+			std::shared_ptr<utils::shm> shm_arg;
+			if (flags & preallocated)
+			{
+				shm_arg = null_shm;
+			}
+			else
+			{
+				const usz idx = ar.pop<usz>();
+				if (idx >= shared.size())
+				{
+					fmt::throw_exception("Invalid shared shm index in savestate: %u (shared.size()=%u)", idx, shared.size());
+				}
+				shm_arg = shared[idx];
+			}
+
+			ensure(try_alloc(addr0, pflags, size0, std::move(shm_arg)));
 
 			if (flags & preallocated)
 			{
 				// Load binary image
 				const u32 guard_size = flags & stack_guarded ? 0x1000 : 0;
+				if (u64{size0} <= u64{guard_size} * 2)
+				{
+					fmt::throw_exception("Invalid page size in block_t savestate: size=0x%x guard_size=0x%x", size0, guard_size);
+				}
 				serialize_memory_bytes(ar, vm::get_super_ptr<u8>(addr0 + guard_size), size0 - guard_size * 2);
 			}
 		}
@@ -2391,13 +2444,22 @@ namespace vm
 			serialize_memory_bytes(ar, shm->map_self(), shm->size());
 		}
 
+		// Validate the count BEFORE we tear down the existing g_locations so a
+		// malformed savestate can't leave the emulator in a half-destroyed state.
+		const usz g_locations_count = ar.pop<usz>();
+		constexpr usz g_locations_max = 64; // Well above the typical vm location count.
+		if (g_locations_count > g_locations_max)
+		{
+			fmt::throw_exception("Invalid g_locations count in savestate: %u (max=%u)", g_locations_count, g_locations_max);
+		}
+
 		for (auto& block : g_locations)
 		{
 			if (block) _unmap_block(block);
 		}
 
 		g_locations.clear();
-		g_locations.resize(ar.pop<usz>());
+		g_locations.resize(g_locations_count);
 
 		for (auto& loc : g_locations)
 		{

--- a/rpcs3/Emu/NP/clans_client.cpp
+++ b/rpcs3/Emu/NP/clans_client.cpp
@@ -401,8 +401,10 @@ namespace clan
 			i++;
 		}
 
+		// Clamp the result count to the writable capacity of the output vector so consumers
+		// don't read past the populated entries based on a server-supplied count.
 		page_result = SceNpClansPagingResult{
-			.count = results_count,
+			.count = std::min<u32>(results_count, ::size32(clan_list)),
 			.total = total_count};
 
 		return SCE_NP_CLANS_SUCCESS;
@@ -569,9 +571,11 @@ namespace clan
 			i++;
 		}
 
+		// Clamp the result count to the writable capacity of the output vector so consumers
+		// don't read past the populated entries based on a server-supplied count.
 		page_result = SceNpClansPagingResult
 		{
-			.count = results_count,
+			.count = std::min<u32>(results_count, ::size32(mem_list)),
 			.total = total_count
 		};
 
@@ -630,9 +634,11 @@ namespace clan
 			i++;
 		}
 
+		// Clamp the result count to the writable capacity of the output vector so consumers
+		// don't read past the populated entries based on a server-supplied count.
 		page_result = SceNpClansPagingResult
 		{
-			.count = results_count,
+			.count = std::min<u32>(results_count, ::size32(bl)),
 			.total = total_count
 		};
 
@@ -728,9 +734,11 @@ namespace clan
 			i++;
 		}
 
+		// Clamp the result count to the writable capacity of the output vector so consumers
+		// don't read past the populated entries based on a server-supplied count.
 		page_result = SceNpClansPagingResult
 		{
-			.count = results_count,
+			.count = std::min<u32>(results_count, ::size32(clan_list)),
 			.total = total_count
 		};
 
@@ -1083,9 +1091,11 @@ namespace clan
 			i++;
 		}
 
+		// Clamp the result count to the writable capacity of the output vector so consumers
+		// don't read past the populated entries based on a server-supplied count.
 		page_result = SceNpClansPagingResult
 		{
-			.count = results_count,
+			.count = std::min<u32>(results_count, ::size32(announcements)),
 			.total = total_count
 		};
 

--- a/rpcs3/Emu/NP/rpcn_client.cpp
+++ b/rpcs3/Emu/NP/rpcn_client.cpp
@@ -3149,10 +3149,21 @@ namespace rpcn
 			return;
 		}
 
+		// Server-supplied values: clamp to u16 instead of using ::narrow which
+		// would throw on out-of-range data from a malicious/buggy RPCN peer.
+		const u32 main_type_raw = pb_mdata->maintype().value();
+		const u32 sub_type_raw  = pb_mdata->subtype().value();
+
+		if (main_type_raw > 0xFFFFu || sub_type_raw > 0xFFFFu)
+		{
+			rpcn_log.warning("Discarded message with out-of-range main/sub type (main=0x%x sub=0x%x)", main_type_raw, sub_type_raw);
+			return;
+		}
+
 		message_data mdata = {
 			.msgId = message_counter,
-			.mainType = ::narrow<u16>(pb_mdata->maintype().value()),
-			.subType = ::narrow<u16>(pb_mdata->subtype().value()),
+			.mainType = static_cast<u16>(main_type_raw),
+			.subType = static_cast<u16>(sub_type_raw),
 			.msgFeatures = pb_mdata->msgfeatures(),
 			.subject = pb_mdata->subject(),
 			.body = pb_mdata->body()};

--- a/rpcs3/Emu/RSX/Common/BufferUtils.cpp
+++ b/rpcs3/Emu/RSX/Common/BufferUtils.cpp
@@ -645,6 +645,11 @@ void write_index_array_for_non_indexed_non_native_primitive_to_buffer(char* dst,
 	switch (draw_mode)
 	{
 	case rsx::primitive_type::line_loop:
+		// Degenerate draw with no vertices: nothing to emit and no closing index.
+		if (!count)
+		{
+			return;
+		}
 		iota16(typedDst, count);
 		typedDst[count] = 0;
 		return;

--- a/rpcs3/Emu/RSX/Common/surface_store.h
+++ b/rpcs3/Emu/RSX/Common/surface_store.h
@@ -1109,6 +1109,14 @@ namespace rsx
 				return {};
 			}
 
+			// (required_pitch * required_height) - (required_pitch - surface_internal_pitch)
+			// underflows when either dimension is zero. Bail out so the result range can't
+			// span the entire address space and pull in unrelated surfaces.
+			if (!required_width || !required_height) [[unlikely]]
+			{
+				return {};
+			}
+
 			const auto test_range = utils::address_range32::start_length(texaddr, (required_pitch * required_height) - (required_pitch - surface_internal_pitch));
 
 			auto process_list_function = [&](surface_ranged_map& data, bool is_depth)

--- a/rpcs3/Emu/RSX/Common/texture_cache.h
+++ b/rpcs3/Emu/RSX/Common/texture_cache.h
@@ -2344,6 +2344,7 @@ namespace rsx
 				attributes.depth = 6;
 				subsurface_count = 1;
 				tex_size = static_cast<u32>(get_texture_size(tex));
+				if (!attributes.pitch) [[unlikely]] return {};
 				required_surface_height = tex_size / attributes.pitch;
 				attributes.slice_h = required_surface_height / attributes.depth;
 				break;
@@ -2351,6 +2352,7 @@ namespace rsx
 				attributes.depth = tex.depth();
 				subsurface_count = 1;
 				tex_size = static_cast<u32>(get_texture_size(tex));
+				if (!attributes.pitch || !attributes.depth) [[unlikely]] return {};
 				required_surface_height = tex_size / attributes.pitch;
 				attributes.slice_h = required_surface_height / attributes.depth;
 				break;

--- a/rpcs3/Emu/RSX/Common/texture_cache.h
+++ b/rpcs3/Emu/RSX/Common/texture_cache.h
@@ -266,7 +266,10 @@ namespace rsx
 						if (section_fills_target(sections[idx]))
 						{
 							const auto remaining = sections.size() - idx;
-							std::memcpy(
+							// memmove (not memcpy) because src (&sections[idx]) and dst (sections.data())
+							// alias the same buffer whenever remaining > idx (i.e. when the surviving
+							// tail overlaps the prefix we're writing into). memcpy is UB in that case.
+							std::memmove(
 								sections.data(),
 								&sections[idx],
 								remaining * sizeof(sections[0])

--- a/rpcs3/Emu/RSX/Common/tiled_dma_copy.hpp
+++ b/rpcs3/Emu/RSX/Common/tiled_dma_copy.hpp
@@ -130,6 +130,15 @@ namespace rsx
 		// Some constants
 		auto get_prime_factor = [](uint32_t pitch) -> std::pair<uint32_t, uint32_t>
 		{
+			// pitch == 0 is a malformed input (a 0-byte row stride is nonsensical for a tiled
+			// surface). Without this guard, (pitch & (pitch - 1)) == 0 succeeds, base is 0, and
+			// the caller computes num_tiles_per_row = 0 — which then divides-by-zero inside
+			// tiled_dma_copy. Return 0/0 so the caller can short-circuit cleanly.
+			if (pitch == 0)
+			{
+				return { 0u, 0u };
+			}
+
 			const uint32_t base = (pitch >> 8);
 			if ((pitch & (pitch - 1)) == 0)
 			{
@@ -150,6 +159,13 @@ namespace rsx
 
 		const auto [prime, factor] = get_prime_factor(row_pitch_in_bytes);
 		const uint32_t tiles_per_row = prime * factor;
+
+		if (tiles_per_row == 0)
+		{
+			// Either pitch == 0 or the pitch had no usable prime factor. Either way there is no
+			// tile grid to walk; bail out instead of dividing by zero in the inner kernel.
+			return;
+		}
 		constexpr int op = Decode ? RSX_DMA_OP_DECODE_TILE : RSX_DMA_OP_ENCODE_TILE;
 
 		auto src2 = static_cast<char*>(const_cast<void*>(src));

--- a/rpcs3/Emu/RSX/GL/GLDMA.cpp
+++ b/rpcs3/Emu/RSX/GL/GLDMA.cpp
@@ -76,7 +76,10 @@ namespace gl
 	utils::address_range32 to_dma_block_range(u32 start, u32 length)
 	{
 		const auto start_block_address = start & s_dma_block_mask;
-		const auto end_block_address = (start + length + s_dma_block_size - 1) & s_dma_block_mask;
+		// Compute end alignment in u64 so a range that ends in the last block of the address
+		// space (start + length near 0x1'0000'0000) does not wrap and produce a giant inverted range.
+		const u64 end64 = (u64{start} + u64{length} + s_dma_block_size - 1) & u64{s_dma_block_mask};
+		const u32 end_block_address = static_cast<u32>(std::min<u64>(end64, 0xFFFF'FFFFull));
 		return utils::address_range32::start_length(start_block_address, end_block_address - start_block_address);
 	}
 

--- a/rpcs3/Emu/RSX/GL/GLDMA.cpp
+++ b/rpcs3/Emu/RSX/GL/GLDMA.cpp
@@ -115,7 +115,14 @@ namespace gl
 			 id += s_dma_block_size)
 		{
 			ensure((id % s_dma_block_size) == 0);
-			g_dma_pool[id]->set_parent(new_owner.get());
+			// Use find() instead of operator[] so we do not default-construct a null unique_ptr and
+			// then dereference it. If a sub-block was never allocated separately (e.g. because the
+			// original allocation already covered this range), there is nothing to reparent here.
+			const auto it = g_dma_pool.find(id);
+			if (it != g_dma_pool.end() && it->second)
+			{
+				it->second->set_parent(new_owner.get());
+			}
 		}
 
 		block = std::move(new_owner);

--- a/rpcs3/Emu/RSX/GL/GLTexture.cpp
+++ b/rpcs3/Emu/RSX/GL/GLTexture.cpp
@@ -191,7 +191,7 @@ namespace gl
 		case texture::internal_format::depth16:
 			return { .format = GL_DEPTH_COMPONENT, .type = GL_UNSIGNED_SHORT, .block_size = 2, .swap_bytes = true };
 		case texture::internal_format::depth32f:
-			return { .format = GL_DEPTH_COMPONENT, .type = GL_FLOAT, .block_size = 2, .swap_bytes = true };
+			return { .format = GL_DEPTH_COMPONENT, .type = GL_FLOAT, .block_size = 4, .swap_bytes = true };
 		case texture::internal_format::depth24_stencil8:
 		case texture::internal_format::depth32f_stencil8:
 			return { .format = GL_DEPTH_STENCIL, .type = GL_UNSIGNED_INT_24_8, .block_size = 4, .swap_bytes = true };

--- a/rpcs3/Emu/RSX/NV47/HW/nv0039.cpp
+++ b/rpcs3/Emu/RSX/NV47/HW/nv0039.cpp
@@ -143,6 +143,15 @@ namespace rsx
 				// The formats are just input channel strides. You can use this to do cool tricks like gathering channels
 				// Very rare, only seen in use by Destiny
 				// TODO: Hw accel
+
+				// A zero stride would either spin the per-row while-loop forever (src_stride == 0)
+				// or never advance the destination (dst_stride == 0). Reject both up front.
+				if (!in_format || !out_format) [[unlikely]]
+				{
+					rsx_log.error("NV0039_BUFFER_NOTIFY rejected: zero channel stride (in_format=%u, out_format=%u)", in_format, out_format);
+					return;
+				}
+
 				block2d_copy_with_stride(dst, src, line_length, line_count, in_pitch, out_pitch, in_format, out_format);
 				return;
 			}

--- a/rpcs3/Emu/RSX/NV47/HW/nv3089.cpp
+++ b/rpcs3/Emu/RSX/NV47/HW/nv3089.cpp
@@ -230,6 +230,14 @@ namespace rsx
 			else
 			{
 				const u16 read_h = std::min(static_cast<u16>(clip_h / scale_y), in_h);
+
+				// (read_h - 1) underflows the in_pitch multiplication when scale_y is large enough
+				// to collapse clip_h/scale_y to 0; treat the zero-height transfer as a NOP.
+				if (read_h == 0)
+				{
+					return { false, src_info, dst_info };
+				}
+
 				const u32 data_length = in_pitch * (read_h - 1) + src_line_length;
 
 				if (src_address = get_address(src_offset, src_dma, data_length); !src_address)

--- a/rpcs3/Emu/RSX/Program/Assembler/FPToCFG.cpp
+++ b/rpcs3/Emu/RSX/Program/Assembler/FPToCFG.cpp
@@ -101,8 +101,23 @@ namespace rsx::assembler
 				src2.reg_type == RSX_FP_REGISTER_TYPE_CONSTANT;
 		};
 
+		// Bound the bytecode walk against the program's declared ucode length AND the architectural
+		// fragment-program instruction ceiling. A malformed guest program that never sets the end
+		// bit would otherwise drive an unbounded read past prog.get_data(). Each FP instruction is
+		// 16 bytes, so pc * 16 is the current byte offset into the ucode buffer. Match the shape
+		// of analyse_fragment_program's hardening (see commit 3f86ff82e).
+		const u32 ucode_length = prog.ucode_length;
+		const u32 max_instructions = std::min<u32>(rsx::max_fragment_program_instructions, ucode_length / 16);
+
 		while (!end)
 		{
+			if (pc >= max_instructions)
+			{
+				// Ran out of declared bytecode without ever seeing the end bit. Treat the trailing
+				// region as a NOP block and stop walking so we don't read past the mapped region.
+				break;
+			}
+
 			BasicBlock** found = end_blocks.find_if(FN(x->id == pc));
 
 			if (!found)

--- a/rpcs3/Emu/RSX/Program/ProgramStateCache.cpp
+++ b/rpcs3/Emu/RSX/Program/ProgramStateCache.cpp
@@ -594,7 +594,11 @@ usz fragment_program_utils::get_fragment_program_ucode_size(const void* ptr)
 {
 	const auto instBuffer = ptr;
 	usz instIndex = 0;
-	while (true)
+
+	// Bound the walk; a guest fragment program that never sets the end bit
+	// would otherwise read past the mapped region indefinitely. Matches the
+	// hardening on analyse_fragment_program.
+	while (instIndex < rsx::max_fragment_program_instructions)
 	{
 		const v128 inst = v128::loadu(instBuffer, instIndex);
 		const bool end = (inst._u32[0] >> 8) & 0x1;
@@ -610,6 +614,9 @@ usz fragment_program_utils::get_fragment_program_ucode_size(const void* ptr)
 		if (end)
 			return (instIndex)* 4 * 4;
 	}
+
+	// No end marker found within the bound; return a NOP-sized program.
+	return 16;
 }
 
 fragment_program_utils::fragment_program_metadata fragment_program_utils::analyse_fragment_program(const void* ptr)

--- a/rpcs3/Emu/RSX/VK/VKTextureCache.cpp
+++ b/rpcs3/Emu/RSX/VK/VKTextureCache.cpp
@@ -13,23 +13,34 @@ namespace vk
 		/**
 		* Key layout:
 		* 00-08: Format  (Max 255)
-		* 08-24: Width   (Max 64K)
-		* 24-40: Height  (Max 64K)
-		* 40-48: Depth   (Max 255)
-		* 48-54: Mipmaps (Max 63)   <- We have some room here, it is not possible to have more than 12 mip levels on PS3 and 16 on PC is pushing it.
-		* 54-56: Type    (Max 3)
-		* 56-57: Sharing (Max 1)    <- Boolean. Exclusive = 0, shared = 1
-		* 57-64: Flags   (Max 127)  <- We have some room here, we only care about a small subset of create flags.
+		* 08-22: Width   (Max 16K)  <- PS3 max texture dimension is 4096; 16K covers PC scratch images.
+		* 22-36: Height  (Max 16K)
+		* 36-46: Depth   (Max 1024) <- PS3 3D textures can be up to 512 deep, so 8 bits would collide.
+		* 46-51: Mipmaps (Max 31)   <- PS3 caps at 12 mip levels, 16 on PC is pushing it.
+		* 51-53: Type    (Max 3)
+		* 53-54: Sharing (Max 1)    <- Boolean. Exclusive = 0, shared = 1
+		* 54-64: Flags   (Max 1023) <- We only care about a small subset of create flags.
+		*
+		* IMPORTANT: every field is masked before being shifted into place so out-of-range values
+		* cannot bleed into adjacent fields and produce a hash collision. The ensure() calls catch
+		* values that exceed the architectural limits we expect — they should never fire in practice.
 		*/
 		ensure(static_cast<u32>(format) <= 0xFF);
+		ensure(w <= 0x3FFF);
+		ensure(h <= 0x3FFF);
+		ensure(d <= 0x3FF);
+		ensure(mipmaps <= 0x1F);
+		ensure(static_cast<u32>(type) <= 0x3);
+		ensure(static_cast<u32>(sharing_mode) <= 0x1);
+
 		return (static_cast<u64>(format) & 0xFF) |
-			(static_cast<u64>(w) << 8) |
-			(static_cast<u64>(h) << 24) |
-			(static_cast<u64>(d) << 40) |
-			(static_cast<u64>(mipmaps) << 48) |
-			(static_cast<u64>(type) << 54) |
-			(static_cast<u64>(sharing_mode) << 56) |
-			(static_cast<u64>(create_flags) << 57);
+			((static_cast<u64>(w) & 0x3FFF) << 8) |
+			((static_cast<u64>(h) & 0x3FFF) << 22) |
+			((static_cast<u64>(d) & 0x3FF) << 36) |
+			((static_cast<u64>(mipmaps) & 0x1F) << 46) |
+			((static_cast<u64>(type) & 0x3) << 51) |
+			((static_cast<u64>(sharing_mode) & 0x1) << 53) |
+			((static_cast<u64>(create_flags) & 0x3FF) << 54);
 	}
 
 	texture_cache::cached_image_reference_t::cached_image_reference_t(texture_cache* parent, std::unique_ptr<vk::viewable_image>& previous)

--- a/rpcs3/Emu/RSX/rsx_utils.h
+++ b/rpcs3/Emu/RSX/rsx_utils.h
@@ -448,13 +448,22 @@ namespace rsx
 		const u32 log2_h = ceil_log2(height);
 		const u32 log2_d = ceil_log2(depth);
 
+		// calculate_z_index interleaves x|y|z bits as if every axis were padded to its next_pow2.
+		// When the actual depth (or width/height) is not a power of two, the computed source
+		// index can land in the [N, next_pow2(N)) gap and read past the source buffer, which the
+		// callers size as exactly width * height * depth elements (not the padded cube).
+		// Clamp the index to that real bound; out-of-range slots get a zero texel, matching the
+		// effect of an unpopulated swizzle cell.
+		const u32 src_element_count = u32{width} * u32{height} * u32{depth};
+
 		for (u32 z = 0; z < depth; ++z)
 		{
 			for (u32 y = 0; y < height; ++y)
 			{
 				for (u32 x = 0; x < width; ++x)
 				{
-					*dst++ = src[calculate_z_index(x, y, z, log2_w, log2_h, log2_d)];
+					const u32 src_index = calculate_z_index(x, y, z, log2_w, log2_h, log2_d);
+					*dst++ = (src_index < src_element_count) ? src[src_index] : T{};
 				}
 			}
 		}

--- a/rpcs3/Loader/ELF.h
+++ b/rpcs3/Loader/ELF.h
@@ -373,7 +373,7 @@ public:
 					// Try to find it in phdr data instead of allocating new section
 					p_index++;
 
-					if (hdr.p_filesz > 0 && shdr.sh_size > 0 && hdr.p_offset <= shdr.sh_offset && shdr.sh_offset + shdr.sh_size - 1 <= hdr.p_offset + hdr.p_filesz - 1)
+					if (hdr.p_filesz > 0 && shdr.sh_size > 0 && hdr.p_offset <= shdr.sh_offset && u64{shdr.sh_offset} + u64{shdr.sh_size} <= u64{hdr.p_offset} + u64{hdr.p_filesz})
 					{
 						const auto& prog = ::at32(progs, p_index);
 						shdrs.back().bin_view = {prog.bin.data() + shdr.sh_offset - hdr.p_offset, shdr.sh_size};
@@ -469,7 +469,7 @@ public:
 					p_index++;
 
 					// Rely on previous sh_offset value!
-					if (hdr.p_filesz > 0 && shdr.sh_size > 0 && hdr.p_offset <= shdr.sh_offset && shdr.sh_offset + shdr.sh_size - 1 <= hdr.p_offset + hdr.p_filesz - 1)
+					if (hdr.p_filesz > 0 && shdr.sh_size > 0 && hdr.p_offset <= shdr.sh_offset && u64{shdr.sh_offset} + u64{shdr.sh_size} <= u64{hdr.p_offset} + u64{hdr.p_filesz})
 					{
 						out.sh_offset = ::narrow<sz_t>(data_base + static_cast<usz>(shdr.sh_offset - hdr.p_offset));
 						result = true;

--- a/rpcs3/Loader/TAR.cpp
+++ b/rpcs3/Loader/TAR.cpp
@@ -231,6 +231,14 @@ bool tar_object::extract(const std::string& prefix_path, bool is_vfs)
 		const TARHeader& header = iter->second.second;
 		const std::string& name = iter->first;
 
+		// Reject path traversal in entry names before any path is formed.
+		// Block "..", absolute paths, and Windows backslashes regardless of VFS mode.
+		if (name.find("..") != umax || name.find('\\') != umax || (!name.empty() && name.front() == '/'))
+		{
+			tar_log.error("TAR Loader: refusing entry with unsafe name '%s'", name);
+			return false;
+		}
+
 		// Backwards compatibility measure
 		const bool should_ignore = name.find(reinterpret_cast<const char*>(u8"＄")) != umax;
 

--- a/rpcs3/Loader/mself.cpp
+++ b/rpcs3/Loader/mself.cpp
@@ -49,7 +49,18 @@ bool extract_mself(const std::string& file, const std::string& extract_to)
 
 	for (const mself_record& rec : recs)
 	{
-		const std::string name = vfs::escape(rec.name);
+		// rec.name is a fixed-size char array with no guaranteed NUL terminator;
+		// strnlen-bound it before any conversion to string/string_view.
+		const std::string raw_name(rec.name, strnlen(rec.name, sizeof(rec.name)));
+
+		// Reject path traversal before forming the extraction path.
+		if (raw_name.find("..") != umax || raw_name.find('\\') != umax || (!raw_name.empty() && raw_name.front() == '/'))
+		{
+			mself_log.error("MSELF: refusing record with unsafe name '%s'", raw_name);
+			return false;
+		}
+
+		const std::string name = vfs::escape(raw_name, true);
 
 		const u64 pos = rec.get_pos(mself_size);
 


### PR DESCRIPTION
## Summary

Seventh hardening round across six subsystems. Each subsystem was reviewed by a dedicated read-only agent that returned high-confidence bug findings; the PM verified the top critical claims by reading the cited files, then dispatched fix agents per subsystem. All commits use the existing `subsystem: short description` style.

### Per-commit overview

- **vm/sys_mmapper: validate savestate block_t fields** — `vm::block_t` and `lv2_memory` loaders previously took attacker-controlled bytes straight from a savestate. Adds bounds for block addr/size/flags, per-page addr0/size0 vs. parent block, shared[] index, guard arithmetic in `serialize_memory_bytes`, page-loop cap, `g_locations` count cap (validated before tearing down state), and a null check on `vm::get()`.
- **sys_*: bound fcntl/prx out-buffers and reject null out-pointers** — `sys_fs_fcntl 0xe0000012` (cellFsGetDirectoryEntries) used a guest-supplied `max` to drive `memset`; `0xc0000007` used unchecked model/serial sizes; `_sys_prx_get_module_info` zero-filled an unbounded span. Plus ~15 null out-pointer guards across sys_fs, sys_process, sys_memory, sys_timer, sys_lwmutex, sys_lwcond, sys_spu, sys_vm, sys_event.
- **cellSync/cellSpurs: re-validate guest-mutable sizes before memcpy** — `m_size`/`size` fields in LFQueue/Rwm/Queue are guest-writable after init. The LFQueue read into `s32` then memcpy'd, so `0xFFFFFFFF` sign-extended to `SIZE_MAX`. `cellSyncQueueInitialize` was also missing an upper bound. `cellSpursGetInfo` clamps `prefixSize` before memcpy.
- **Audio: validate savestate fields and guard backend enumerator nulls** — `cell_audio_thread`'s load ctor previously accepted any audio_port[] / keys count from the savestate. Now validates state/num_channels/num_blocks/cur_pos/prev_touched_tag_nr and caps keys at `MAX_AUDIO_EVENT_QUEUES`. `audio_out_configuration` bounds `sound_modes` to 16. Cubeb and XAudio2 enumerators null-check device_id/friendly_name before string construction.
- **rsx: harden backends, swizzle math, and tiled DMA** — GL DMA pool uses `find()` instead of `operator[]` (null-deref fix); `FPToCFG::deconstruct_fragment_program` bounded by `ucode_length`; VK texture cache hash masks each packed field (depth widened to 10 bits to fit PS3 3D textures); `texture_cache::simplify` uses `memmove`; `tiled_dma_copy` short-circuits on `num_tiles_per_row == 0`; `convert_linear_swizzle_3d` bounds the source index for non-power-of-two depth.
- **cellGame/Rtc/Gcm/Http/Trophy/NP** — Theme install caps SHA input to bufSize; `cellRtcSetTick` rejects tick > `RTC_SYSTEM_TIME_MAX`; `cellRtcTickAddMonths` uses s64; date parsers cap their scans; `cellGcmMapMainMemory` guards the offsetTable scan; gcm current+2 overflow check uses u64; `sceNpTrophyCreateContext` rejects path-traversal characters in `commId->data`; `cellHttpUtilParseUri` rejects null pool with non-null uri; `clans_client` clamps `page_result.count` so a hostile RPCN response can't drive an OOB heap read.
- **PPU: fix MULLI/MULLD signed-overflow UB and bound PRX/savestate walks** — Multiply low-64 in u64 (defined wrap); guard `.eh_frame` `ptr[5]` against `sec_end`; PRX reloc loop uses `usz` and bounds by `min(p_filesz, bin.size())`; `ppu_patch_refs` caps iterations; savestate `joiner` is validated against `ppu_join_status::max` and the `status` switch gets a throwing `default:` arm.

## Methodology

Six parallel read-only Explore-style agents, one per subsystem cluster (PPU CPU, Audio, Memory+savestate, Cell HLE non-audio, sys_*, RSX backends), each told to return high-confidence findings only. The PM (Claude) verified top critical claims by reading the cited file:line directly, then dispatched seven parallel fix agents — each scoped to a single commit theme — with explicit instructions to skip any finding the surrounding code didn't support. ~73 findings produced; ~60 were fixed (the rest were either intentional patterns, already addressed in prior rounds, or too speculative on re-reading).

## Test plan

- [ ] CI build passes (Windows + Linux + macOS).
- [ ] Boot a representative title to confirm no regression in the hot paths (PPU MULLI/MULLD, audio backend init, RSX tiled DMA, sys_fs syscalls).
- [ ] Load a known-good savestate to confirm the new validation paths in `vm::block_t`, `cell_audio_thread`, and `ppu_thread` ctors do not reject legitimate saves.
- [ ] Attempt to load a hand-modified savestate (e.g. with an oversized block_t header) and confirm it throws cleanly instead of crashing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)