### PR TITLE
Round 8: SPU/41, Loader/Crypto, sys_*, decoders, Input, cheats

### DIFF
--- a/Utilities/cheat_info.cpp
+++ b/Utilities/cheat_info.cpp
@@ -32,7 +32,8 @@ bool cheat_info::from_str(std::string_view cheat_line)
 	const auto cheat_vec = fmt::split(cheat_line, {"@@@"}, false);
 
 	s64 val64 = 0;
-	if (cheat_vec.size() != 5 || !try_to_int64(&val64, cheat_vec[2], 0, cheat_type_max - 1))
+	u64 uval64 = 0;
+	if (cheat_vec.size() != 5 || !try_to_int64(&val64, cheat_vec[2], 0, cheat_type_max - 1) || !try_to_uint64(&uval64, cheat_vec[3], 0, UINT32_MAX))
 	{
 		log_cheat.error("Failed to parse cheat line: '%s'", cheat_line);
 		return false;
@@ -41,7 +42,7 @@ bool cheat_info::from_str(std::string_view cheat_line)
 	game        = cheat_vec[0];
 	description = cheat_vec[1];
 	type        = cheat_type{::narrow<u8>(val64)};
-	offset      = std::stoul(cheat_vec[3]);
+	offset      = static_cast<u32>(uval64);
 	red_script  = cheat_vec[4];
 
 	return true;

--- a/rpcs3/Crypto/unedat.cpp
+++ b/rpcs3/Crypto/unedat.cpp
@@ -829,9 +829,12 @@ bool EDATADecrypter::ReadHeader()
 			//
 		}
 		// Type 2: Use key from RAP file (RIF key). (also used for type 1 at the moment)
-		else 
+		else
 		{
-			const std::string rap_path = rpcs3::utils::get_rap_file_path(npdHeader.content_id);
+			// NPD_HEADER::content_id is char[0x30] without a guaranteed terminator;
+			// bound the string to the field size to avoid reading past the buffer.
+			const std::string content_id_str(npdHeader.content_id, strnlen(npdHeader.content_id, sizeof(npdHeader.content_id)));
+			const std::string rap_path = rpcs3::utils::get_rap_file_path(content_id_str);
 
 			if (fs::file rap{rap_path}; rap && rap.size() >= sizeof(dec_key))
 			{
@@ -867,7 +870,13 @@ bool EDATADecrypter::ReadHeader()
 	}
 
 	file_size = edatHeader.file_size;
-	total_blocks = ::narrow<u32>(utils::aligned_div(edatHeader.file_size, edatHeader.block_size));
+	const u64 total_blocks_u64 = utils::aligned_div(edatHeader.file_size, edatHeader.block_size);
+	if (total_blocks_u64 > UINT32_MAX)
+	{
+		edat_log.error("NPDRM EDAT has too many blocks 0x%llx (file_size=0x%llx, block_size=0x%x)", total_blocks_u64, edatHeader.file_size, edatHeader.block_size);
+		return false;
+	}
+	total_blocks = static_cast<u32>(total_blocks_u64);
 
 	// Try decrypting the first block instead
 	u8 data_sample[1];
@@ -893,7 +902,9 @@ u64 EDATADecrypter::ReadData(u64 pos, u8* data, u64 size)
 	// Now we need to offset things to account for the actual 'range' requested
 	const u64 startOffset = pos % edatHeader.block_size;
 
-	const u64 num_blocks = utils::aligned_div(startOffset + size, edatHeader.block_size);
+	// Guard against u64 overflow when computing the block window for this read.
+	const u64 window = utils::add_saturate<u64>(startOffset, size);
+	const u64 num_blocks = utils::aligned_div(window, edatHeader.block_size);
 
 	// Find and decrypt block range covering pos + size
 	const u32 starting_block = ::narrow<u32>(pos / edatHeader.block_size);

--- a/rpcs3/Crypto/unpkg.cpp
+++ b/rpcs3/Crypto/unpkg.cpp
@@ -10,6 +10,7 @@
 #include "Emu/VFS.h"
 #include "unpkg.h"
 #include "util/sysinfo.hpp"
+#include "util/asm.hpp"
 #include "Loader/PSF.h"
 
 #include <filesystem>
@@ -190,7 +191,7 @@ bool package_reader::read_header()
 		m_file = fs::make_gather(std::move(filelist));
 	}
 
-	if (m_header.data_size + m_header.data_offset > m_header.pkg_size)
+	if (utils::add_saturate<u64>(m_header.data_size, m_header.data_offset) > m_header.pkg_size)
 	{
 		pkg_log.error("PKG data size mismatch (data_size=0x%llx, data_offset=0x%llx, file_size=0x%llx)", m_header.data_size, m_header.data_offset, m_header.pkg_size);
 		return false;
@@ -208,6 +209,18 @@ bool package_reader::read_metadata()
 	// Read package metadata
 
 	archive_seek(m_header.meta_offset);
+
+	// Each metadata packet is at minimum 8 bytes (id + size). Reject obviously bogus
+	// meta_count values before iterating, so we don't spend forever consuming garbage.
+	const u64 max_meta_count = m_header.meta_offset < m_header.pkg_size
+		? (m_header.pkg_size - m_header.meta_offset) / 8
+		: 0;
+
+	if (m_header.meta_count > max_meta_count)
+	{
+		pkg_log.error("PKG meta_count=0x%x exceeds available space after meta_offset (max=0x%llx)", m_header.meta_count, max_meta_count);
+		return false;
+	}
 
 	for (u32 i = 0; i < m_header.meta_count; i++)
 	{
@@ -355,7 +368,8 @@ bool package_reader::read_metadata()
 		}
 		case 0xA:
 		{
-			if (packet.size > 8)
+			// Bound install-dir packets to a sane range: must be > 8 (header) and not absurdly large.
+			if (packet.size > 8 && packet.size <= 1024)
 			{
 				// Read an actual installation directory (DLC)
 				m_install_dir.resize(packet.size);
@@ -526,6 +540,15 @@ bool package_reader::set_decryption_key()
 bool package_reader::read_entries(std::vector<PKGEntry>& entries)
 {
 	entries.clear();
+
+	// Cap file_count against the actual PKG size to prevent a guest-controlled
+	// gigantic allocation when the header reports an absurd number of entries.
+	if (m_header.file_count > m_file.size() / sizeof(PKGEntry))
+	{
+		pkg_log.error("PKG file_count=0x%x exceeds file capacity (file_size=0x%llx)", m_header.file_count, m_file.size());
+		return false;
+	}
+
 	entries.resize(m_header.file_count + BUF_PADDING / sizeof(PKGEntry) + 1);
 
 	const usz read_size = decrypt(0, m_header.file_count * sizeof(PKGEntry), m_header.pkg_platform == PKG_PLATFORM_TYPE_PSP_PSVITA ? PKG_AES_KEY2 : m_dec_key.data(), entries.data());

--- a/rpcs3/Crypto/unself.cpp
+++ b/rpcs3/Crypto/unself.cpp
@@ -8,49 +8,49 @@
 
 inline u8 Read8(const fs::file& f)
 {
-	u8 ret;
+	u8 ret{};
 	f.read(&ret, sizeof(ret));
 	return ret;
 }
 
 inline u16 Read16(const fs::file& f)
 {
-	be_t<u16> ret;
+	be_t<u16> ret{};
 	f.read(&ret, sizeof(ret));
 	return ret;
 }
 
 inline u32 Read32(const fs::file& f)
 {
-	be_t<u32> ret;
+	be_t<u32> ret{};
 	f.read(&ret, sizeof(ret));
 	return ret;
 }
 
 inline u64 Read64(const fs::file& f)
 {
-	be_t<u64> ret;
+	be_t<u64> ret{};
 	f.read(&ret, sizeof(ret));
 	return ret;
 }
 
 inline u16 Read16LE(const fs::file& f)
 {
-	u16 ret;
+	u16 ret{};
 	f.read(&ret, sizeof(ret));
 	return ret;
 }
 
 inline u32 Read32LE(const fs::file& f)
 {
-	u32 ret;
+	u32 ret{};
 	f.read(&ret, sizeof(ret));
 	return ret;
 }
 
 inline u64 Read64LE(const fs::file& f)
 {
-	u64 ret;
+	u64 ret{};
 	f.read(&ret, sizeof(ret));
 	return ret;
 }
@@ -323,7 +323,7 @@ void supplemental_header::Show() const
 		self_log.notice("Version: 0x%08x", PS3_npdrm_header.npd.version);
 		self_log.notice("License: 0x%08x", PS3_npdrm_header.npd.license);
 		self_log.notice("Type: 0x%08x", PS3_npdrm_header.npd.type);
-		self_log.notice("ContentID: %s", PS3_npdrm_header.npd.content_id);
+		self_log.notice("ContentID: %s", std::string(PS3_npdrm_header.npd.content_id, strnlen(PS3_npdrm_header.npd.content_id, sizeof(PS3_npdrm_header.npd.content_id))));
 		self_log.notice("Digest: %s", PS3_npdrm_header.npd.digest);
 		self_log.notice("Inverse digest: %s", PS3_npdrm_header.npd.title_hash);
 		self_log.notice("XOR digest: %s", PS3_npdrm_header.npd.dev_hash);
@@ -632,6 +632,13 @@ bool SCEDecrypter::LoadMetadata(const u8 erk[32], const u8 riv[16])
 		return false;
 	}
 	const auto metadata_headers_size = sce_hdr.se_hsize - (sizeof(sce_hdr) + sce_hdr.se_meta + sizeof(meta_info));
+	// Cap metadata headers size to avoid a guest-controlled gigantic allocation. 64 MiB is way more
+	// than any real SCE metadata block and also no larger than the file itself.
+	if (metadata_headers_size > sce_f.size() || metadata_headers_size > (64u << 20))
+	{
+		self_log.error("SCE metadata_headers_size 0x%llx is implausible (file size 0x%llx)", metadata_headers_size, sce_f.size());
+		return false;
+	}
 	const auto metadata_headers = std::make_unique<u8[]>(metadata_headers_size);
 
 	// Locate and read the encrypted metadata info.
@@ -705,11 +712,26 @@ bool SCEDecrypter::DecryptData()
 {
 	aes_context aes;
 
-	// Calculate the total data size.
+	// Calculate the total data size with overflow protection.
+	u64 total_size = 0;
 	for (unsigned int i = 0; i < meta_hdr.section_count; i++)
 	{
-		data_buf_length += ::narrow<u32>(meta_shdr[i].data_size);
+		// Reject any single section that is implausibly large.
+		if (meta_shdr[i].data_size > sce_f.size())
+		{
+			self_log.error("SCE section %u has out-of-bounds data_size 0x%llx (file size 0x%llx)", i, +meta_shdr[i].data_size, sce_f.size());
+			return false;
+		}
+
+		total_size += meta_shdr[i].data_size;
+		if (total_size > UINT32_MAX)
+		{
+			self_log.error("SCE total decrypted data size exceeds 4 GiB (overflow at section %u)", i);
+			return false;
+		}
 	}
+
+	data_buf_length = ::narrow<u32>(total_size);
 
 	// Allocate a buffer to store decrypted data.
 	data_buf = std::make_unique<u8[]>(data_buf_length);
@@ -834,11 +856,24 @@ bool SELFDecrypter::LoadHeaders(bool isElf32, SelfAdditionalInfo* out_info)
 		return false;
 	}
 
+	// Helper: verify that [offset, offset + len) lies within the file before seeking.
+	auto seek_checked = [&](u64 offset, u64 len) -> bool
+	{
+		if (offset > self_size || utils::add_saturate<u64>(offset, len) > self_size)
+		{
+			self_log.error("SELF header references out-of-bounds region (offset=0x%llx, len=0x%llx, file=0x%llx)", offset, len, self_size);
+			return false;
+		}
+		self_f.seek(offset);
+		return true;
+	};
+
 	// Read SELF header.
 	m_ext_hdr.Load(self_f);
 
 	// Read the APP INFO.
-	self_f.seek(m_ext_hdr.program_identification_hdr_offset);
+	if (!seek_checked(m_ext_hdr.program_identification_hdr_offset, sizeof(program_identification_header)))
+		return false;
 	m_prog_id_hdr.Load(self_f);
 
 	if (out_info)
@@ -847,7 +882,8 @@ bool SELFDecrypter::LoadHeaders(bool isElf32, SelfAdditionalInfo* out_info)
 	}
 
 	// Read ELF header.
-	self_f.seek(m_ext_hdr.ehdr_offset);
+	if (!seek_checked(m_ext_hdr.ehdr_offset, isElf32 ? sizeof(Elf32_Ehdr) : sizeof(Elf64_Ehdr)))
+		return false;
 
 	if (isElf32)
 		elf32_hdr.Load(self_f);
@@ -863,7 +899,8 @@ bool SELFDecrypter::LoadHeaders(bool isElf32, SelfAdditionalInfo* out_info)
 			self_log.error("ELF program header offset is null!");
 			return false;
 		}
-		self_f.seek(m_ext_hdr.phdr_offset);
+		if (!seek_checked(m_ext_hdr.phdr_offset, u64{elf32_hdr.e_phnum} * sizeof(Elf32_Phdr)))
+			return false;
 		for(u32 i = 0; i < elf32_hdr.e_phnum; ++i)
 		{
 			phdr32_arr.emplace_back();
@@ -880,7 +917,8 @@ bool SELFDecrypter::LoadHeaders(bool isElf32, SelfAdditionalInfo* out_info)
 			return false;
 		}
 
-		self_f.seek(m_ext_hdr.phdr_offset);
+		if (!seek_checked(m_ext_hdr.phdr_offset, u64{elf64_hdr.e_phnum} * sizeof(Elf64_Phdr)))
+			return false;
 
 		for (u32 i = 0; i < elf64_hdr.e_phnum; ++i)
 		{
@@ -891,7 +929,8 @@ bool SELFDecrypter::LoadHeaders(bool isElf32, SelfAdditionalInfo* out_info)
 
 	// Read section info.
 	m_seg_ext_hdr.clear();
-	self_f.seek(m_ext_hdr.segment_ext_hdr_offset);
+	if (!seek_checked(m_ext_hdr.segment_ext_hdr_offset, 0))
+		return false;
 
 	for(u32 i = 0; i < (isElf32 ? elf32_hdr.e_phnum : elf64_hdr.e_phnum); ++i)
 	{
@@ -925,10 +964,20 @@ bool SELFDecrypter::LoadHeaders(bool isElf32, SelfAdditionalInfo* out_info)
 
 	// Read control info.
 	m_supplemental_hdr_arr.clear();
-	self_f.seek(m_ext_hdr.supplemental_hdr_offset);
+	if (!seek_checked(m_ext_hdr.supplemental_hdr_offset, 0))
+		return false;
 
+	// Cap iteration count to keep malformed files from looping forever.
+	constexpr u64 kMaxSupplementalHeaders = 1024;
+	u64 supplemental_iters = 0;
 	for (u64 i = 0; i < m_ext_hdr.supplemental_hdr_size;)
 	{
+		if (++supplemental_iters > kMaxSupplementalHeaders)
+		{
+			self_log.error("SELF supplemental header iteration cap exceeded");
+			return false;
+		}
+
 		if (self_f.pos() >= self_size)
 		{
 			// Read out of bounds (file is truncated or corrupted)
@@ -938,6 +987,15 @@ bool SELFDecrypter::LoadHeaders(bool isElf32, SelfAdditionalInfo* out_info)
 		m_supplemental_hdr_arr.emplace_back();
 		supplemental_header& cinfo = m_supplemental_hdr_arr.back();
 		cinfo.Load(self_f);
+
+		// Reject zero/under-sized advances to prevent infinite looping.
+		// 16 bytes is the size of the fixed header (type + size + next) and the absolute
+		// minimum any real supplemental header can occupy.
+		if (cinfo.size < 16u)
+		{
+			self_log.error("SELF supplemental header has invalid size 0x%x", cinfo.size);
+			return false;
+		}
 		i += cinfo.size;
 	}
 
@@ -957,7 +1015,8 @@ bool SELFDecrypter::LoadHeaders(bool isElf32, SelfAdditionalInfo* out_info)
 			return true;
 		}
 
-		self_f.seek(m_ext_hdr.shdr_offset);
+		if (!seek_checked(m_ext_hdr.shdr_offset, u64{elf32_hdr.e_shnum} * sizeof(Elf32_Shdr)))
+			return false;
 
 		for(u32 i = 0; i < elf32_hdr.e_shnum; ++i)
 		{
@@ -974,7 +1033,8 @@ bool SELFDecrypter::LoadHeaders(bool isElf32, SelfAdditionalInfo* out_info)
 			return true;
 		}
 
-		self_f.seek(m_ext_hdr.shdr_offset);
+		if (!seek_checked(m_ext_hdr.shdr_offset, u64{elf64_hdr.e_shnum} * sizeof(Elf64_Shdr)))
+			return false;
 
 		for(u32 i = 0; i < elf64_hdr.e_shnum; ++i)
 		{
@@ -1117,6 +1177,13 @@ bool SELFDecrypter::LoadMetadata(const u8* klic_key)
 		return false;
 	}
 	const auto metadata_headers_size = sce_hdr.se_hsize - (sizeof(sce_hdr) + sce_hdr.se_meta + sizeof(meta_info));
+	// Cap metadata headers size to avoid a guest-controlled gigantic allocation. 64 MiB is way more
+	// than any real SELF metadata block and also no larger than the file itself.
+	if (metadata_headers_size > self_f.size() || metadata_headers_size > (64u << 20))
+	{
+		self_log.error("SELF metadata_headers_size 0x%llx is implausible (file size 0x%llx)", metadata_headers_size, self_f.size());
+		return false;
+	}
 	const auto metadata_headers = std::make_unique<u8[]>(metadata_headers_size);
 
 	// Locate and read the encrypted metadata info.
@@ -1201,15 +1268,32 @@ bool SELFDecrypter::DecryptData()
 {
 	aes_context aes;
 
-	// Calculate the total data size.
+	// Calculate the total data size with overflow protection.
+	u64 total_size = 0;
 	for (unsigned int i = 0; i < meta_hdr.section_count; i++)
 	{
 		if (meta_shdr[i].encrypted == 3)
 		{
 			if ((meta_shdr[i].key_idx < meta_hdr.key_count) && (meta_shdr[i].iv_idx < meta_hdr.key_count))
-				data_buf_length += ::narrow<u32>(meta_shdr[i].data_size);
+			{
+				// Reject any single section that is implausibly large.
+				if (meta_shdr[i].data_size > self_f.size())
+				{
+					self_log.error("SELF section %u has out-of-bounds data_size 0x%llx (file size 0x%llx)", i, +meta_shdr[i].data_size, self_f.size());
+					return false;
+				}
+
+				total_size += meta_shdr[i].data_size;
+				if (total_size > UINT32_MAX)
+				{
+					self_log.error("SELF total decrypted data size exceeds 4 GiB (overflow at section %u)", i);
+					return false;
+				}
+			}
 		}
 	}
+
+	data_buf_length = ::narrow<u32>(total_size);
 
 	// Allocate a buffer to store decrypted data.
 	data_buf = std::make_unique<u8[]>(data_buf_length);
@@ -1285,7 +1369,9 @@ bool SELFDecrypter::GetKeyFromRap(const char* content_id, u8* npdrm_key)
 	memset(rap_key, 0, 0x10);
 
 	// Try to find a matching RAP file under exdata folder.
-	const std::string ci_str = content_id;
+	// NPD_HEADER::content_id is a fixed-size char[0x30] that may not be null-terminated;
+	// bound the string to the field size to avoid reading past the buffer.
+	const std::string ci_str(content_id, strnlen(content_id, 0x30));
 	const std::string rap_path = rpcs3::utils::get_rap_file_path(ci_str);
 
 	// Open the RAP file and read the key.

--- a/rpcs3/Crypto/unself.h
+++ b/rpcs3/Crypto/unself.h
@@ -503,6 +503,20 @@ private:
 			// PHDR type.
 			if (meta_shdr[i].type == 2)
 			{
+				// data_buf only contains sections that DecryptData() actually copied
+				// (encrypted == 3 with valid key/iv indices). Mirror that filter here
+				// so data_buf_offset stays in sync.
+				const bool in_data_buf = meta_shdr[i].encrypted == 3
+					&& meta_shdr[i].key_idx < meta_hdr.key_count
+					&& meta_shdr[i].iv_idx < meta_hdr.key_count;
+
+				if (!in_data_buf)
+				{
+					// Nothing was decrypted for this section; skip the write entirely
+					// and do not advance data_buf_offset.
+					continue;
+				}
+
 				// Decompress if necessary.
 				if (meta_shdr[i].compressed == 2)
 				{

--- a/rpcs3/Emu/Cell/Modules/cellGifDec.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellGifDec.cpp
@@ -589,7 +589,7 @@ error_code cellGifDecDecodeData(vm::ptr<GifDecoder> mainHandle, vm::cptr<GifStre
 		}
 		else
 		{
-			const auto img = std::make_unique<uint[]>(image_size);
+			const auto img = std::make_unique<uint[]>(image_size / sizeof(uint));
 			uint* source_current = reinterpret_cast<uint*>(image.get());
 			uint* dest_current = img.get();
 			for (uint i = 0; i < image_size / nComponents; i++)

--- a/rpcs3/Emu/Cell/Modules/cellJpgDec.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellJpgDec.cpp
@@ -337,7 +337,7 @@ error_code cellJpgDecDecodeData(u32 mainHandle, u32 subHandle, vm::ptr<u8> data,
 		}
 		else
 		{
-			std::vector<u32> img(image_size);
+			std::vector<u32> img(image_size / sizeof(u32));
 			const u32* source_current = reinterpret_cast<const u32*>(image.get());
 			u32* dest_current = img.data();
 			for (u32 i = 0; i < image_size / nComponents; i++)

--- a/rpcs3/Emu/Cell/Modules/cellPamf.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellPamf.cpp
@@ -600,9 +600,10 @@ error_code pamfVerify(vm::cptr<PamfHeader> pAddr, u64 fileSize, vm::ptr<CellPamf
 		next_ep_table_addr += ep_num * sizeof(PamfEpHeader);
 	}
 
-	// This can overflow on LLE, the +4 is necessary on both sides and the left operand needs to be u32
-	if (group_size + 4 > grouping_period_size - offsetof(PamfGroupingPeriod, groups) + sizeof(u32)
-		|| grouping_period_size + 4 > seq_info_size - offsetof(PamfSequenceInfo, grouping_periods) + sizeof(u32))
+	// This can overflow on LLE, the +4 is necessary on both sides and the left operand needs to be u32.
+	// Reordered to additive form to avoid unsigned wrap when sizes are smaller than the constant offsets.
+	if (group_size + 4 + offsetof(PamfGroupingPeriod, groups) > grouping_period_size + sizeof(u32)
+		|| grouping_period_size + 4 + offsetof(PamfSequenceInfo, grouping_periods) > seq_info_size + sizeof(u32))
 	{
 		return { CELL_PAMF_ERROR_INVALID_PAMF, "pamfVerify() failed: size mismatch" };
 	}
@@ -647,6 +648,12 @@ error_code pamfVerify(vm::cptr<PamfHeader> pAddr, u64 fileSize, vm::ptr<CellPamf
 	}
 	else if (psmf_marks_offset != 0 && !(attribute & CELL_PAMF_ATTRIBUTE_MINIMUM_HEADER))
 	{
+		// The marks header reads a u32 at +0 and a u16 at +6, so it requires at least 8 bytes.
+		if (psmf_marks_size < 8)
+		{
+			return { CELL_PAMF_ERROR_INVALID_PAMF, "pamfVerify() failed: psmf_marks_size too small" };
+		}
+
 		const u32 size = vm::read32(pAddr.addr() + psmf_marks_offset);
 
 		if (size + sizeof(u32) != psmf_marks_size)

--- a/rpcs3/Emu/Cell/Modules/cellPngDec.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellPngDec.cpp
@@ -146,7 +146,15 @@ void pngDecRowCallback(png_structp png_ptr, png_bytep new_row, png_uint_32 row_n
 	if (pass > 0)
 		data = static_cast<u8*>(stream->cbDispParam->nextOutputImage.get_ptr());
 	else
+	{
+		// Guard against guest-provided outputStartY exceeding row_num which would
+		// underflow the unsigned subtraction and produce an OOB write.
+		if (row_num < stream->cbDispInfo->outputStartY)
+		{
+			return;
+		}
 		data = static_cast<u8*>(stream->cbDispParam->nextOutputImage.get_ptr()) + ((row_num - stream->cbDispInfo->outputStartY) * stream->cbDispInfo->outputFrameWidthByte);
+	}
 
 	png_progressive_combine_row(png_ptr, data, new_row);
 }
@@ -466,6 +474,13 @@ error_code pngDecOpen(ppu_thread& ppu, PHandle handle, PPStream png_stream, PSrc
 	}
 	else
 	{
+		// Reject obviously bogus stream sizes: PNG header is 8 bytes, and we cap
+		// the in-memory stream to 256 MiB to prevent unbounded guest-driven reads.
+		if (stream->source.streamSize < 8 || stream->source.streamSize > 0x10000000)
+		{
+			return CELL_PNGDEC_ERROR_STREAM_FORMAT;
+		}
+
 		// We can simply copy the first 8 bytes
 		memcpy(header, stream->source.streamPtr.get_ptr(), 8);
 	}
@@ -501,6 +516,7 @@ error_code pngDecOpen(ppu_thread& ppu, PHandle handle, PPStream png_stream, PSrc
 
 	if (source->srcSelect == CELL_PNGDEC_BUFFER)
 	{
+		// streamSize was already bounds-checked above when reading the header
 		buffer->length = stream->source.streamSize;
 		buffer->data = stream->source.streamPtr;
 		buffer->cursor = 8;
@@ -713,6 +729,16 @@ error_code pngDecodeData(ppu_thread& ppu, PHandle handle, PStream stream, vm::pt
 		fmt::throw_exception("Bytes per line less than expected output! Got: %d, expected: %d", bytes_per_line, stream->out_param.outputWidthByte);
 	}
 
+	// Reject absurd line strides from the guest. Cap at outputWidthByte plus a
+	// reasonable padding allowance, and reject combinations that would overflow.
+	const u32 output_width_byte = stream->out_param.outputWidthByte;
+	const u32 output_height = stream->out_param.outputHeight;
+	if (bytes_per_line > output_width_byte + 0x1000u
+		|| (output_height != 0 && bytes_per_line > std::numeric_limits<u32>::max() / output_height))
+	{
+		return CELL_PNGDEC_ERROR_ARG;
+	}
+
 	// partial decoding
 	if (cb_control_disp && stream->outputCounts > 0)
 	{
@@ -760,9 +786,34 @@ error_code pngDecodeData(ppu_thread& ppu, PHandle handle, PStream stream, vm::pt
 
 		// todo: commandPtr
 		// then just loop until the end, the callbacks should take care of the rest
+		// Cap iteration count and per-chunk size so a misbehaving guest callback can't
+		// keep us looping forever or feed unbounded buffers into libpng.
+		constexpr u32 kMaxStrmSize = 0x10000000; // 256 MiB per chunk
+		constexpr u32 kMaxIterations = 0x100000;
+		u32 iterations = 0;
 		while (stream->endOfFile != true)
 		{
+			if (++iterations > kMaxIterations)
+			{
+				freeMem();
+				return CELL_PNGDEC_ERROR_STREAM_FORMAT;
+			}
+
 			stream->cbCtrlStream.cbCtrlStrmFunc(ppu, streamInfo, streamParam, stream->cbCtrlStream.cbCtrlStrmArg);
+
+			if (streamParam->strmSize > kMaxStrmSize)
+			{
+				freeMem();
+				return CELL_PNGDEC_ERROR_STREAM_FORMAT;
+			}
+
+			// Detect accumulator overflow before updating decodedStrmSize
+			if (streamInfo->decodedStrmSize + streamParam->strmSize < streamInfo->decodedStrmSize)
+			{
+				freeMem();
+				return CELL_PNGDEC_ERROR_STREAM_FORMAT;
+			}
+
 			streamInfo->decodedStrmSize += streamParam->strmSize;
 			png_process_data(stream->png_ptr, stream->info_ptr, static_cast<u8*>(streamParam->strmPtr.get_ptr()), streamParam->strmSize);
 		}

--- a/rpcs3/Emu/Cell/Modules/cellSearch.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellSearch.cpp
@@ -1313,7 +1313,7 @@ error_code cellSearchStartSceneSearch(CellSearchSceneSearchType searchType, vm::
 
 		for (u32 n = 0; n < tagNum; n++)
 		{
-			if (!tags[tagNum] || !memchr(&tags[tagNum], '\0', CELL_SEARCH_TAG_LEN_MAX))
+			if (!tags[n] || !memchr(&tags[n], '\0', CELL_SEARCH_TAG_LEN_MAX))
 			{
 				return CELL_SEARCH_ERROR_TAG;
 			}
@@ -1403,7 +1403,7 @@ error_code cellSearchGetContentInfoByOffset(CellSearchId searchId, s32 offset, v
 			if (infoBuffer) std::memcpy(infoBuffer.get_ptr(), &content_info->data.photo, sizeof(content_info->data.photo));
 			break;
 		case CELL_SEARCH_CONTENTTYPE_VIDEO:
-			if (infoBuffer) std::memcpy(infoBuffer.get_ptr(), &content_info->data.video, sizeof(content_info->data.photo));
+			if (infoBuffer) std::memcpy(infoBuffer.get_ptr(), &content_info->data.video, sizeof(content_info->data.video));
 			break;
 		case CELL_SEARCH_CONTENTTYPE_MUSICLIST:
 			if (infoBuffer) std::memcpy(infoBuffer.get_ptr(), &content_info->data.music_list, sizeof(content_info->data.music_list));
@@ -1476,7 +1476,7 @@ error_code cellSearchGetContentInfoByContentId(vm::cptr<CellSearchContentId> con
 			if (infoBuffer) std::memcpy(infoBuffer.get_ptr(), &content_info->data.photo, sizeof(content_info->data.photo));
 			break;
 		case CELL_SEARCH_CONTENTTYPE_VIDEO:
-			if (infoBuffer) std::memcpy(infoBuffer.get_ptr(), &content_info->data.video, sizeof(content_info->data.photo));
+			if (infoBuffer) std::memcpy(infoBuffer.get_ptr(), &content_info->data.video, sizeof(content_info->data.video));
 			break;
 		case CELL_SEARCH_CONTENTTYPE_MUSICLIST:
 			if (infoBuffer) std::memcpy(infoBuffer.get_ptr(), &content_info->data.music_list, sizeof(content_info->data.music_list));

--- a/rpcs3/Emu/Cell/Modules/cellSubDisplay.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellSubDisplay.cpp
@@ -381,10 +381,7 @@ error_code cellSubDisplayGetTouchInfo(s32 groupId, vm::ptr<CellSubDisplayTouchIn
 		return CELL_SUBDISPLAY_ERROR_NOT_SUPPORTED;
 	}
 
-	if (*pNumTouchInfo > CELL_SUBDISPLAY_TOUCH_MAX_TOUCH_INFO)
-	{
-		*pNumTouchInfo = CELL_SUBDISPLAY_TOUCH_MAX_TOUCH_INFO;
-	}
+	*pNumTouchInfo = std::clamp<s32>(*pNumTouchInfo, 0, CELL_SUBDISPLAY_TOUCH_MAX_TOUCH_INFO);
 
 	std::memcpy(pTouchInfo.get_ptr(), manager.touch_info.data(), *pNumTouchInfo * sizeof(CellSubDisplayTouchInfo));
 

--- a/rpcs3/Emu/Cell/Modules/sceNp.cpp
+++ b/rpcs3/Emu/Cell/Modules/sceNp.cpp
@@ -3733,6 +3733,10 @@ error_code sceNpLookupTitleSmallStorageAsync(s32 transId, vm::ptr<void> data, u3
 	}
 
 	// TSS are game specific data we don't have access to, set buf to 0, return size 0
+	if (maxSize > SCE_NP_TSS_MAX_SIZE)
+	{
+		return SCE_NP_COMMUNITY_ERROR_BODY_TOO_LARGE;
+	}
 	std::memset(data.get_ptr(), 0, maxSize);
 	*contentLength = 0;
 
@@ -5668,6 +5672,12 @@ error_code scenp_score_record_score(s32 transId, SceNpScoreBoardId boardId, SceN
 
 			data = &option->vsInfo->data[0];
 			data_size = option->vsInfo->infoSize;
+
+			// vsInfo->data is a fixed-size buffer; reject sizes that would read past it.
+			if (data_size > SCE_NP_SCORE_VARIABLE_SIZE_GAMEINFO_MAXSIZE)
+			{
+				return SCE_NP_COMMUNITY_ERROR_INVALID_ARGUMENT;
+			}
 		}
 	}
 	else

--- a/rpcs3/Emu/Cell/SPUCommonRecompiler.cpp
+++ b/rpcs3/Emu/Cell/SPUCommonRecompiler.cpp
@@ -3045,7 +3045,7 @@ spu_program spu_recompiler_base::analyse(const be_t<u32>* ls, u32 entry_point, s
 
 						if (+iflags & +spu_iflag::use_rc)
 						{
-							is_no_return = is_no_return || (op_next.ra >= 4 && op_next.rb < 10);
+							is_no_return = is_no_return || (op_next.rc >= 4 && op_next.rc < 10);
 						}
 					}
 				}
@@ -4464,7 +4464,7 @@ spu_program spu_recompiler_base::analyse(const be_t<u32>* ls, u32 entry_point, s
 		for (u32 ia = addr; ia < addr + bb.size * 4; ia += 4)
 		{
 			// Decode instruction again
-			op.opcode = std::bit_cast<be_t<u32>>(result.data[(ia - lsa) / 41]);
+			op.opcode = std::bit_cast<be_t<u32>>(result.data[(ia - lsa) / 4]);
 			last_inst = g_spu_itype.decode(op.opcode);
 
 			// Propagate some constants

--- a/rpcs3/Emu/Cell/SPUThread.cpp
+++ b/rpcs3/Emu/Cell/SPUThread.cpp
@@ -2462,6 +2462,10 @@ void spu_thread::do_dma_transfer(spu_thread* _this, const spu_mfc_cmd& args, u8*
 
 		perf_meter<"DMA_PUT"_u64> perf2 = perf_;
 
+		// Snapshot original dst/src for the mfc_debug dump below, since some switch arms advance them past the end of the transfer.
+		u8* const dump_dst_orig = dst;
+		const u8* const dump_src_orig = src;
+
 		switch (u32 size = args.size)
 		{
 		case 1:
@@ -2653,13 +2657,20 @@ void spu_thread::do_dma_transfer(spu_thread* _this, const spu_mfc_cmd& args, u8*
 			dump.cmd = args;
 			dump.cmd.eah = _this->pc;
 			dump.block_hash = _this->block_hash;
-			std::memcpy(dump.data, is_get ? dst : src, std::min<u32>(args.size, 128));
+			std::memcpy(dump.data, is_get ? dump_dst_orig : dump_src_orig, std::min<u32>(args.size, 128));
 		}
 
 		return;
 	}
 
 plain_access:
+
+	// Snapshot original dst/src for the mfc_debug dump below, since the default switch arm advances them past the end of the transfer.
+	// Declared inside a block so a goto to plain_access does not jump over the initialization.
+	u8* dump_dst_orig2;
+	const u8* dump_src_orig2;
+	dump_dst_orig2 = dst;
+	dump_src_orig2 = src;
 
 	switch (u32 size = args.size)
 	{
@@ -2730,7 +2741,7 @@ plain_access:
 		dump.cmd = args;
 		dump.cmd.eah = _this->pc;
 		dump.block_hash = _this->block_hash;
-		std::memcpy(dump.data, is_get ? dst : src, std::min<u32>(args.size, 128));
+		std::memcpy(dump.data, is_get ? dump_dst_orig2 : dump_src_orig2, std::min<u32>(args.size, 128));
 	}
 }
 

--- a/rpcs3/Emu/Cell/lv2/sys_config.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_config.cpp
@@ -1,5 +1,6 @@
 #include "stdafx.h"
 #include "Emu/IdManager.h"
+#include "Emu/Memory/vm.h"
 
 #include "Emu/Cell/lv2/sys_event.h"
 #include "Emu/Cell/ErrorCodes.h"
@@ -301,6 +302,11 @@ error_code sys_config_open(u32 equeue_hdl, vm::ptr<u32> out_config_hdl)
 {
 	sys_config.trace("sys_config_open(equeue_hdl=0x%x, out_config_hdl=*0x%x)", equeue_hdl, out_config_hdl);
 
+	if (!out_config_hdl)
+	{
+		return CELL_EFAULT;
+	}
+
 	// Find queue with the given ID
 	const auto queue = idm::get_unlocked<lv2_obj, lv2_event_queue>(equeue_hdl);
 	if (!queue)
@@ -377,6 +383,22 @@ error_code sys_config_add_service_listener(u32 config_hdl, sys_config_service_id
 {
 	sys_config.trace("sys_config_add_service_listener(config_hdl=0x%x, service_id=0x%llx, min_verbosity=0x%llx, in=*0x%x, size=%lld, type=0x%llx, out_listener_hdl=*0x%x)", config_hdl, service_id, min_verbosity, in, size, type, out_listener_hdl);
 
+	if (!out_listener_hdl)
+	{
+		return CELL_EFAULT;
+	}
+
+	// Validate guest-supplied buffer/size before passing to the listener ctor
+	if (size > 0x1000)
+	{
+		return CELL_EINVAL;
+	}
+
+	if (size > 0 && (!in || !vm::check_addr(in.addr(), vm::page_readable, size)))
+	{
+		return CELL_EFAULT;
+	}
+
 	// Find sys_config handle object with the given ID
 	auto cfg = idm::get_unlocked<lv2_config_handle>(config_hdl);
 	if (!cfg)
@@ -424,6 +446,22 @@ error_code sys_config_remove_service_listener(u32 config_hdl, u32 listener_hdl)
 error_code sys_config_register_service(u32 config_hdl, sys_config_service_id service_id, u64 user_id, u64 verbosity, vm::ptr<u8> data_buf, u64 size, vm::ptr<u32> out_service_hdl)
 {
 	sys_config.trace("sys_config_register_service(config_hdl=0x%x, service_id=0x%llx, user_id=0x%llx, verbosity=0x%llx, data_but=*0x%llx, size=%lld, out_service_hdl=*0x%llx)", config_hdl, service_id, user_id, verbosity, data_buf, size, out_service_hdl);
+
+	if (!out_service_hdl)
+	{
+		return CELL_EFAULT;
+	}
+
+	// Validate guest-supplied buffer/size before passing to the service ctor
+	if (size > 0x1000)
+	{
+		return CELL_EINVAL;
+	}
+
+	if (size > 0 && (!data_buf || !vm::check_addr(data_buf.addr(), vm::page_readable, size)))
+	{
+		return CELL_EFAULT;
+	}
 
 	// Find sys_config handle object with the given ID
 	const auto cfg = idm::get_unlocked<lv2_config_handle>(config_hdl);

--- a/rpcs3/Emu/Cell/lv2/sys_hid.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_hid.cpp
@@ -1,6 +1,7 @@
 #include "stdafx.h"
 #include "sys_hid.h"
 
+#include "Emu/Memory/vm.h"
 #include "Emu/Memory/vm_var.h"
 
 #include "Emu/Cell/PPUThread.h"
@@ -70,6 +71,12 @@ error_code sys_hid_manager_ioctl(u32 hid_handle, u32 pkg_id, vm::ptr<void> buf, 
 	{
 		// Return what realhw seems to return
 		// TODO: Figure out what this corresponds to
+		if (!buf || buf_size < sizeof(sys_hid_info_2) ||
+			!vm::check_addr(buf.addr(), vm::page_writable, sizeof(sys_hid_info_2)))
+		{
+			return CELL_EFAULT;
+		}
+
 		auto info = vm::static_ptr_cast<sys_hid_info_2>(buf);
 		info->vid = 0x054C;
 		info->pid = 0x0268;
@@ -79,6 +86,12 @@ error_code sys_hid_manager_ioctl(u32 hid_handle, u32 pkg_id, vm::ptr<void> buf, 
 	}
 	else if (pkg_id == 5)
 	{
+		if (!buf || buf_size < sizeof(sys_hid_info_5) ||
+			!vm::check_addr(buf.addr(), vm::page_writable, sizeof(sys_hid_info_5)))
+		{
+			return CELL_EFAULT;
+		}
+
 		auto info = vm::static_ptr_cast<sys_hid_info_5>(buf);
 		info->vid = 0x054C;
 		info->pid = 0x0268;
@@ -86,6 +99,12 @@ error_code sys_hid_manager_ioctl(u32 hid_handle, u32 pkg_id, vm::ptr<void> buf, 
 	// pkg_id == 6 == setpressmode?
 	else if (pkg_id == 0x68)
 	{
+		if (!buf || buf_size < sizeof(sys_hid_ioctl_68) ||
+			!vm::check_addr(buf.addr(), vm::page_writable, sizeof(sys_hid_ioctl_68)))
+		{
+			return CELL_EFAULT;
+		}
+
 		[[maybe_unused]] auto info = vm::static_ptr_cast<sys_hid_ioctl_68>(buf);
 		//info->unk2 = 0;
 	}
@@ -170,7 +189,12 @@ error_code sys_hid_manager_read(u32 handle, u32 pkg_id, vm::ptr<void> buf, u64 b
 		vm::var<CellPadData> tmpData;
 		if ((cellPadGetData(0, +tmpData) == CELL_OK) && tmpData->len > 0)
 		{
-			u64 cpySize = std::min(static_cast<u64>(tmpData->len) * sizeof(u16), buf_size * sizeof(u16));
+			// buf_size is the caller-provided byte count; don't multiply it by sizeof(u16)
+			const u64 cpySize = std::min<u64>(static_cast<u64>(tmpData->len) * sizeof(u16), buf_size);
+			if (cpySize && !vm::check_addr(buf.addr(), vm::page_writable, cpySize))
+			{
+				return CELL_EFAULT;
+			}
 			memcpy(buf.get_ptr(), &tmpData->button, cpySize);
 			return not_an_error(cpySize);
 		}
@@ -181,7 +205,12 @@ error_code sys_hid_manager_read(u32 handle, u32 pkg_id, vm::ptr<void> buf, u64 b
 		vm::var<CellPadData> tmpData;
 		if ((cellPadGetData(0, +tmpData) == CELL_OK) && tmpData->len > 0)
 		{
-			u64 cpySize = std::min(static_cast<u64>(tmpData->len) * sizeof(u16), buf_size * sizeof(u16));
+			// buf_size is the caller-provided byte count; don't multiply it by sizeof(u16)
+			const u64 cpySize = std::min<u64>(static_cast<u64>(tmpData->len) * sizeof(u16), buf_size);
+			if (cpySize && !vm::check_addr(buf.addr(), vm::page_writable, cpySize))
+			{
+				return CELL_EFAULT;
+			}
 			memcpy(buf.get_ptr(), &tmpData->button, cpySize);
 			return not_an_error(cpySize / 2);
 		}

--- a/rpcs3/Emu/Cell/lv2/sys_net.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_net.cpp
@@ -281,7 +281,11 @@ std::function<void(void*)> lv2_socket::load(utils::serial& ar)
 	case SYS_NET_SOCK_RAW: sock_lv2 = make_shared<lv2_socket_raw>(ar, type); break;
 	case SYS_NET_SOCK_DGRAM_P2P: sock_lv2 = make_shared<lv2_socket_p2p>(ar, type); break;
 	case SYS_NET_SOCK_STREAM_P2P: sock_lv2 = make_shared<lv2_socket_p2ps>(ar, type); break;
+	default:
+		fmt::throw_exception("lv2_socket::load: unknown lv2_socket_type 0x%x in savestate", static_cast<s32>(type));
 	}
+
+	ensure(sock_lv2);
 
 	if (std::memcmp(&sock_lv2->last_bound_addr, std::array<u8, 16>{}.data(), 16))
 	{
@@ -1114,6 +1118,23 @@ error_code sys_net_bnet_setsockopt(ppu_thread& ppu, s32 s, s32 level, s32 optnam
 		break;
 	}
 
+	if (optlen < sizeof(s32))
+	{
+		return -SYS_NET_EINVAL;
+	}
+
+	// The largest legitimate socket option (e.g. sys_net_ip_mreq, sys_net_linger) is well under 256 bytes;
+	// reject larger inputs so a guest cannot drive multi-GB allocations via this syscall.
+	if (optlen > 256)
+	{
+		return -SYS_NET_EINVAL;
+	}
+
+	if (!optval || !vm::check_addr(optval.addr(), vm::page_readable, optlen))
+	{
+		return -SYS_NET_EFAULT;
+	}
+
 	switch (optlen)
 	{
 	case 1:
@@ -1128,18 +1149,6 @@ error_code sys_net_bnet_setsockopt(ppu_thread& ppu, s32 s, s32 level, s32 optnam
 	case 8:
 		sys_net.warning("optval: 0x%016X", *static_cast<const be_t<u64>*>(optval.get_ptr()));
 		break;
-	}
-
-	if (optlen < sizeof(s32))
-	{
-		return -SYS_NET_EINVAL;
-	}
-
-	// The largest legitimate socket option (e.g. sys_net_ip_mreq, sys_net_linger) is well under 256 bytes;
-	// reject larger inputs so a guest cannot drive multi-GB allocations via this syscall.
-	if (optlen > 256)
-	{
-		return -SYS_NET_EINVAL;
 	}
 
 	std::vector<u8> optval_copy(vm::_ptr<u8>(optval.addr()), vm::_ptr<u8>(optval.addr() + optlen));
@@ -1280,6 +1289,18 @@ error_code sys_net_bnet_poll(ppu_thread& ppu, vm::ptr<sys_net_pollfd> fds, s32 n
 	if (nfds <= 0)
 	{
 		return not_an_error(0);
+	}
+
+	// Cap nfds to a sane limit (FD_SETSIZE on most systems is 1024)
+	constexpr s32 sys_net_poll_nfds_max = 1024;
+	if (nfds > sys_net_poll_nfds_max)
+	{
+		return -SYS_NET_EINVAL;
+	}
+
+	if (!fds || !vm::check_addr(fds.addr(), vm::page_readable, nfds * sizeof(sys_net_pollfd)))
+	{
+		return -SYS_NET_EFAULT;
 	}
 
 	atomic_t<s32> signaled{0};
@@ -1861,6 +1882,11 @@ error_code sys_net_infoctl(ppu_thread& ppu, s32 cmd, vm::ptr<void> arg)
 	{
 	case 9:
 	{
+		if (!arg || !vm::check_addr(arg.addr(), vm::page_writable, sizeof(net_infoctl_cmd_9_t)))
+		{
+			return -SYS_NET_EFAULT;
+		}
+
 		constexpr auto nameserver = "nameserver \0"sv;
 
 		char buffer[nameserver.size() + 80]{};
@@ -1871,8 +1897,16 @@ error_code sys_net_infoctl(ppu_thread& ppu, s32 cmd, vm::ptr<void> arg)
 		std::memcpy(buffer + nameserver.size() - 1, dns_str.data(), dns_str.size());
 
 		std::string_view name{buffer};
-		vm::static_ptr_cast<net_infoctl_cmd_9_t>(arg)->zero = 0;
-		std::memcpy(vm::static_ptr_cast<net_infoctl_cmd_9_t>(arg)->server_name.get_ptr(), name.data(), name.size());
+		auto cmd_arg = vm::static_ptr_cast<net_infoctl_cmd_9_t>(arg);
+		cmd_arg->zero = 0;
+
+		const auto server_name = cmd_arg->server_name;
+		if (!server_name || !vm::check_addr(server_name.addr(), vm::page_writable, name.size()))
+		{
+			return -SYS_NET_EFAULT;
+		}
+
+		std::memcpy(server_name.get_ptr(), name.data(), name.size());
 		break;
 	}
 	default: break;

--- a/rpcs3/Emu/Cell/lv2/sys_rsxaudio.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_rsxaudio.cpp
@@ -45,7 +45,14 @@ namespace rsxaudio_ringbuf_reader
 
 	static void set_timestamp(rsxaudio_shmem::ringbuf_t& ring_buf, u64 timestamp)
 	{
-		const s32 entry_idx_raw = (ring_buf.read_idx + ring_buf.rw_max_idx - (ring_buf.rw_max_idx > 2) - 1) % ring_buf.rw_max_idx;
+		// Snapshot guest-writable field; treat 0 as no-op to avoid divide-by-zero
+		const s32 rw_max_idx = ring_buf.rw_max_idx;
+		if (rw_max_idx <= 0)
+		{
+			return;
+		}
+
+		const s32 entry_idx_raw = (ring_buf.read_idx + rw_max_idx - (rw_max_idx > 2) - 1) % rw_max_idx;
 		const s32 entry_idx = std::clamp<s32>(entry_idx_raw, 0, SYS_RSXAUDIO_RINGBUF_SZ - 1);
 
 		ring_buf.entries[entry_idx].timestamp = convert_to_timebased_time(timestamp);
@@ -53,6 +60,14 @@ namespace rsxaudio_ringbuf_reader
 
 	static std::tuple<bool /*notify*/, u64 /*blk_idx*/, u64 /*timestamp*/> update_status(rsxaudio_shmem::ringbuf_t& ring_buf)
 	{
+		// Snapshot guest-writable fields; treat 0 as no-op to avoid divide-by-zero
+		const s32 rw_max_idx = ring_buf.rw_max_idx;
+		const s32 queue_notify_step = ring_buf.queue_notify_step;
+		if (rw_max_idx <= 0 || queue_notify_step <= 0)
+		{
+			return {};
+		}
+
 		const s32 read_idx = std::clamp<s32>(ring_buf.read_idx, 0, SYS_RSXAUDIO_RINGBUF_SZ - 1);
 
 		if ((ring_buf.entries[read_idx].valid & 1) == 0U)
@@ -60,14 +75,14 @@ namespace rsxaudio_ringbuf_reader
 			return {};
 		}
 
-		const s32 entry_idx_raw = (ring_buf.read_idx + ring_buf.rw_max_idx - (ring_buf.rw_max_idx > 2)) % ring_buf.rw_max_idx;
+		const s32 entry_idx_raw = (ring_buf.read_idx + rw_max_idx - (rw_max_idx > 2)) % rw_max_idx;
 		const s32 entry_idx = std::clamp<s32>(entry_idx_raw, 0, SYS_RSXAUDIO_RINGBUF_SZ - 1);
 
 		ring_buf.entries[read_idx].valid = 0;
-		ring_buf.queue_notify_idx = (ring_buf.queue_notify_idx + 1) % ring_buf.queue_notify_step;
-		ring_buf.read_idx         = (ring_buf.read_idx + 1) % ring_buf.rw_max_idx;
+		ring_buf.queue_notify_idx = (ring_buf.queue_notify_idx + 1) % queue_notify_step;
+		ring_buf.read_idx         = (ring_buf.read_idx + 1) % rw_max_idx;
 
-		return std::make_tuple(((ring_buf.rw_max_idx > 2) ^ ring_buf.queue_notify_idx) == 0, ring_buf.entries[entry_idx].audio_blk_idx, ring_buf.entries[entry_idx].timestamp);
+		return std::make_tuple(((rw_max_idx > 2) ^ ring_buf.queue_notify_idx) == 0, ring_buf.entries[entry_idx].audio_blk_idx, ring_buf.entries[entry_idx].timestamp);
 	}
 
 	static std::pair<bool /*entry_valid*/, u32 /*addr*/> get_addr(const rsxaudio_shmem::ringbuf_t& ring_buf)
@@ -113,6 +128,15 @@ lv2_rsxaudio::lv2_rsxaudio(utils::serial& ar) noexcept
 	if (init)
 	{
 		ar(shmem);
+
+		// Validate guest-supplied shmem address from savestate to avoid OOB access
+		if (!shmem || !vm::check_addr(shmem, vm::page_readable | vm::page_writable, sizeof(rsxaudio_shmem)))
+		{
+			sys_rsxaudio.error("lv2_rsxaudio savestate: invalid shmem address 0x%x, resetting init", u32{shmem});
+			shmem = vm::addr_t{};
+			init = false;
+			return;
+		}
 
 		for (auto& port : event_queue)
 		{

--- a/rpcs3/Emu/Cell/lv2/sys_ss.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_ss.cpp
@@ -120,6 +120,11 @@ error_code sys_ss_random_number_generator(u64 pkg_id, vm::ptr<void> buf, u64 siz
 				return CELL_ENOSYS;
 			}
 
+			if (!buf || !vm::check_addr(buf.addr(), vm::page_writable, 0x18))
+			{
+				return CELL_EFAULT;
+			}
+
 			sys_ss.todo("sys_ss_random_number_generator(): pkg_id=1");
 			std::memset(buf.get_ptr(), 0, 0x18);
 			return CELL_OK;
@@ -132,6 +137,11 @@ error_code sys_ss_random_number_generator(u64 pkg_id, vm::ptr<void> buf, u64 siz
 	if (size > 0x10000000)
 	{
 		return SYS_SS_RNG_ERROR_ENOMEM;
+	}
+
+	if (!buf || !vm::check_addr(buf.addr(), vm::page_writable, size))
+	{
+		return CELL_EFAULT;
 	}
 
 	std::unique_ptr<u8[]> temp(new u8[size]);
@@ -176,12 +186,24 @@ error_code sys_ss_access_control_engine(u64 pkg_id, u64 a2, u64 a3)
 		}
 
 		ensure(a2 == static_cast<u64>(process_getpid()));
-		vm::write64(vm::cast(a3), authid);
+		{
+			const u32 a3_addr = vm::cast(a3);
+			if (!a3_addr || !vm::check_addr(a3_addr, vm::page_writable, 8))
+			{
+				return CELL_EFAULT;
+			}
+			vm::write64(a3_addr, authid);
+		}
 		break;
 	}
 	case 0x2:
 	{
-		vm::write64(vm::cast(a2), authid);
+		const u32 a2_addr = vm::cast(a2);
+		if (!a2_addr || !vm::check_addr(a2_addr, vm::page_writable, 8))
+		{
+			return CELL_EFAULT;
+		}
+		vm::write64(a2_addr, authid);
 		break;
 	}
 	case 0x3:
@@ -315,10 +337,19 @@ error_code sys_ss_secure_rtc(u64 cmd, u64 a2, u64 a3, u64 a4)
 		if (a2 > 1)
 			return 0x80010500; // bad packet id
 
+		const u32 a3_addr = ::narrow<u32>(a3);
+		const u32 a4_addr = ::narrow<u32>(a4);
+
+		if (!a3_addr || !vm::check_addr(a3_addr, vm::page_writable, 8) ||
+			!a4_addr || !vm::check_addr(a4_addr, vm::page_writable, 8))
+		{
+			return CELL_EFAULT;
+		}
+
 		// a3 is actual output, not 100% sure, but best guess is its tb val
-		vm::write64(::narrow<u32>(a3), get_timebased_time());
+		vm::write64(a3_addr, get_timebased_time());
 		// a4 is a pointer to status, non 0 on error
-		vm::write64(::narrow<u32>(a4), 0);
+		vm::write64(a4_addr, 0);
 		return CELL_OK;
 	}
 	else if (cmd == 0x3003)
@@ -473,6 +504,10 @@ error_code sys_ss_update_manager(u64 pkg_id, u64 a1, u64 a2, u64 a3, u64 a4, u64
 		if (!addr_ptr)
 			return CELL_EFAULT;
 
+		// Cap to a sane firmware-like upper bound and reject zero
+		if (size == 0 || size > 0x4000000)
+			return CELL_ENOMEM;
+
 		const auto addr = update_manager.allocate(size);
 
 		if (!addr)
@@ -519,6 +554,10 @@ error_code sys_ss_update_manager(u64 pkg_id, u64 a1, u64 a2, u64 a3, u64 a4, u64
 		if (!addr_ptr)
 			return CELL_EFAULT;
 
+		// Cap to a sane firmware-like upper bound and reject zero
+		if (size == 0 || size > 0x4000000)
+			return CELL_ENOMEM;
+
 		const auto addr = update_manager.allocate(size);
 
 		if (!addr)
@@ -560,11 +599,22 @@ error_code sys_ss_individual_info_manager(u64 pkg_id, u64 a2, vm::ptr<u64> out_s
 	case 0x17002:
 	{
 		// TODO
-		vm::write<u64>(static_cast<u32>(a5), a4); // Write back size of buffer
+		const u32 a5_addr = static_cast<u32>(a5);
+		if (!a5_addr || !vm::check_addr(a5_addr, vm::page_writable, 8))
+		{
+			return CELL_EFAULT;
+		}
+		vm::write<u64>(a5_addr, a4); // Write back size of buffer
 		break;
 	}
 	// Get EID size
-	case 0x17001: *out_size = 0x100; break;
+	case 0x17001:
+		if (!out_size)
+		{
+			return CELL_EFAULT;
+		}
+		*out_size = 0x100;
+		break;
 	default: break;
 	}
 

--- a/rpcs3/Input/evdev_joystick_handler.cpp
+++ b/rpcs3/Input/evdev_joystick_handler.cpp
@@ -221,6 +221,12 @@ bool evdev_joystick_handler::update_device(const std::shared_ptr<PadDevice>& dev
 	if (ret < 0)
 	{
 		evdev_log.error("Failed to initialize libevdev for joystick: %s [errno %d]", strerror(-ret), -ret);
+		if (dev)
+		{
+			libevdev_free(dev);
+			dev = nullptr;
+		}
+		close(fd);
 		return false;
 	}
 

--- a/rpcs3/Input/ps_move_calibration.cpp
+++ b/rpcs3/Input/ps_move_calibration.cpp
@@ -163,13 +163,27 @@ void psmove_calibration_get_usb_accel_values(const reports::ps_move_calibration_
 		break;
 	}
 
+	// Guard against malicious/corrupt device data that would make a divisor zero (Inf factor)
+	if (x2 == x1 || y2 == y1 || z2 == z1)
+	{
+		move_log.error("psmove_calibration_get_usb_accel_values: invalid calibration data (zero range): x=(%d,%d) y=(%d,%d) z=(%d,%d)", x1, x2, y1, y2, z1, z2);
+		device.calibration.is_valid = false;
+		device.calibration.accel_x_factor = 1.0f;
+		device.calibration.accel_y_factor = 1.0f;
+		device.calibration.accel_z_factor = 1.0f;
+		device.calibration.accel_x_offset = 0.0f;
+		device.calibration.accel_y_offset = 0.0f;
+		device.calibration.accel_z_offset = 0.0f;
+		return;
+	}
+
 	device.calibration.accel_x_factor = 2.0f / static_cast<float>(x2 - x1);
 	device.calibration.accel_y_factor = 2.0f / static_cast<float>(y2 - y1);
 	device.calibration.accel_z_factor = 2.0f / static_cast<float>(z2 - z1);
 
 	device.calibration.accel_x_offset = -(device.calibration.accel_x_factor * static_cast<float>(x1)) - 1.0f;
-	device.calibration.accel_y_offset = -(device.calibration.accel_y_factor * static_cast<float>(x1)) - 1.0f;
-	device.calibration.accel_z_offset = -(device.calibration.accel_z_factor * static_cast<float>(x1)) - 1.0f;
+	device.calibration.accel_y_offset = -(device.calibration.accel_y_factor * static_cast<float>(y1)) - 1.0f;
+	device.calibration.accel_z_offset = -(device.calibration.accel_z_factor * static_cast<float>(z1)) - 1.0f;
 }
 
 void psmove_calibration_get_usb_gyro_values(const reports::ps_move_calibration_blob& calibration, ps_move_device& device)
@@ -193,6 +207,20 @@ void psmove_calibration_get_usb_gyro_values(const reports::ps_move_calibration_b
 
 		constexpr f32 calibration_rpm = 80.0f;
 		constexpr f32 factor = calibration_rpm * rpm_to_rad_per_sec;
+
+		// Guard against malicious/corrupt device data that would make a divisor zero
+		if (x == 0 || y == 0 || z == 0)
+		{
+			move_log.error("psmove_calibration_get_usb_gyro_values (ZCM1): invalid calibration data (zero divisor): x=%d y=%d z=%d", x, y, z);
+			device.calibration.is_valid = false;
+			device.calibration.gyro_x_gain = 1.0f;
+			device.calibration.gyro_y_gain = 1.0f;
+			device.calibration.gyro_z_gain = 1.0f;
+			device.calibration.gyro_x_offset = 0;
+			device.calibration.gyro_y_offset = 0;
+			device.calibration.gyro_z_offset = 0;
+			break;
+		}
 
 		// Per frame drift taken into account using adjusted gain values
 		device.calibration.gyro_x_gain = factor / static_cast<float>(x);
@@ -223,6 +251,20 @@ void psmove_calibration_get_usb_gyro_values(const reports::ps_move_calibration_b
 		constexpr f32 calibration_hi = calibration_rpm * rpm_to_rad_per_sec;
 		constexpr f32 calibration_low = -calibration_rpm * rpm_to_rad_per_sec;
 		constexpr f32 factor = calibration_hi - calibration_low;
+
+		// Guard against malicious/corrupt device data that would make a divisor zero
+		if (x2 == x1 || y2 == y1 || z2 == z1)
+		{
+			move_log.error("psmove_calibration_get_usb_gyro_values (ZCM2): invalid calibration data (zero range): x=(%d,%d) y=(%d,%d) z=(%d,%d)", x1, x2, y1, y2, z1, z2);
+			device.calibration.is_valid = false;
+			device.calibration.gyro_x_gain = 1.0f;
+			device.calibration.gyro_y_gain = 1.0f;
+			device.calibration.gyro_z_gain = 1.0f;
+			device.calibration.gyro_x_offset = static_cast<f32>(dx);
+			device.calibration.gyro_y_offset = static_cast<f32>(dy);
+			device.calibration.gyro_z_offset = static_cast<f32>(dz);
+			break;
+		}
 
 		// Compute the gain value (the slope of the gyro reading/angular speed line)
 		device.calibration.gyro_x_gain = factor / static_cast<f32>(x2 - x1);

--- a/rpcs3/Input/ps_move_handler.cpp
+++ b/rpcs3/Input/ps_move_handler.cpp
@@ -319,7 +319,10 @@ void ps_move_handler::check_add_device(hid_device* hidDevice, hid_enumerated_dev
 
 	ps_move_calibration_blob calibration {};
 
-	for (int i = 0; i < 2; i++)
+	// ZCM1 has three calibration blocks (0x00, 0x01, 0x82); ZCM2 has two (0x00, 0x81)
+	const int num_calibration_blocks = (device->model == ps_move_model::ZCM1) ? 3 : 2;
+
+	for (int i = 0; i < num_calibration_blocks; i++)
 	{
 		std::array<u8, PSMOVE_CALIBRATION_SIZE> cal {};
 		cal[0] = 0x10;
@@ -327,6 +330,14 @@ void ps_move_handler::check_add_device(hid_device* hidDevice, hid_enumerated_dev
 		if (res < 0)
 		{
 			move_log.error("connect_move_device: hid_get_feature_report 0x10 (calibration) failed! result=%d, error=%s", res, hid_error(device->hidDevice));
+			device->calibration.is_valid = false;
+			break;
+		}
+
+		// Require the device to return the full feature report; otherwise parsing would consume zero-initialized tail bytes
+		if (res != static_cast<int>(cal.size()))
+		{
+			move_log.error("connect_move_device: hid_get_feature_report 0x10 (calibration) returned short report: %d of %zu bytes", res, cal.size());
 			device->calibration.is_valid = false;
 			break;
 		}

--- a/rpcs3/Input/raw_mouse_handler.cpp
+++ b/rpcs3/Input/raw_mouse_handler.cpp
@@ -232,8 +232,12 @@ void raw_mouse::update_values(const RAWMOUSE& state)
 			// Adjust mouse position if the window size changed
 			if (m_window_width_old != m_window_width || m_window_height_old != m_window_height)
 			{
-				m_pos_x = static_cast<int>(std::round((m_pos_x / static_cast<f32>(m_window_width_old)) * m_window_width));
-				m_pos_y = static_cast<int>(std::round((m_pos_y / static_cast<f32>(m_window_height_old)) * m_window_height));
+				// On the first frame the old dimensions are 0, so skip the rescale to avoid division by zero
+				if (m_window_width_old != 0 && m_window_height_old != 0)
+				{
+					m_pos_x = static_cast<int>(std::round((m_pos_x / static_cast<f32>(m_window_width_old)) * m_window_width));
+					m_pos_y = static_cast<int>(std::round((m_pos_y / static_cast<f32>(m_window_height_old)) * m_window_height));
+				}
 
 				m_window_width_old = m_window_width;
 				m_window_height_old = m_window_height;
@@ -316,8 +320,8 @@ void raw_mouse_handler::Init(const u32 max_connect)
 		m_info.status[i] = connected_mice.contains(i) ? CELL_MOUSE_STATUS_CONNECTED : CELL_MOUSE_STATUS_DISCONNECTED;
 		m_info.mode[i] = CELL_MOUSE_INFO_TABLET_MOUSE_MODE;
 		m_info.tablet_is_supported[i] = CELL_MOUSE_INFO_TABLET_NOT_SUPPORTED;
-		m_info.vendor_id[0] = 0x1234;
-		m_info.product_id[0] = 0x1234;
+		m_info.vendor_id[i] = 0x1234;
+		m_info.product_id[i] = 0x1234;
 	}
 
 	type = mouse_handler::raw;

--- a/rpcs3/Loader/ELF.h
+++ b/rpcs3/Loader/ELF.h
@@ -344,12 +344,18 @@ public:
 
 		progs.clear();
 		progs.reserve(_phdrs.size());
+		const usz stream_size_for_elf = stream.size();
 		for (const auto& hdr : _phdrs)
 		{
 			static_cast<phdr_t&>(progs.emplace_back()) = hdr;
 
 			if (!(opts & elf_opt::no_data))
 			{
+				// Reject p_filesz values larger than the underlying stream — a malformed
+				// ELF could otherwise drive a multi-GiB allocation via std::vector::resize.
+				if (u64{hdr.p_filesz} > stream_size_for_elf)
+					return set_error(elf_error::stream_data);
+
 				seek_pos = offset + hdr.p_offset;
 				highest_offset = std::max<usz>(highest_offset, seek_pos);
 

--- a/rpcs3/Loader/TAR.cpp
+++ b/rpcs3/Loader/TAR.cpp
@@ -232,8 +232,25 @@ bool tar_object::extract(const std::string& prefix_path, bool is_vfs)
 		const std::string& name = iter->first;
 
 		// Reject path traversal in entry names before any path is formed.
-		// Block "..", absolute paths, and Windows backslashes regardless of VFS mode.
-		if (name.find("..") != umax || name.find('\\') != umax || (!name.empty() && name.front() == '/'))
+		// Split on '/' and block any component equal to ".." or ".".
+		// Also block Windows backslashes and absolute paths regardless of VFS mode.
+		auto has_unsafe_component = [](const std::string& n)
+		{
+			usz start = 0;
+			while (start <= n.size())
+			{
+				const usz end = n.find('/', start);
+				const std::string_view comp(n.data() + start, (end == umax ? n.size() : end) - start);
+				if (comp == ".." || comp == ".")
+					return true;
+				if (end == umax)
+					break;
+				start = end + 1;
+			}
+			return false;
+		};
+
+		if (has_unsafe_component(name) || name.find('\\') != umax || (!name.empty() && name.front() == '/'))
 		{
 			tar_log.error("TAR Loader: refusing entry with unsafe name '%s'", name);
 			return false;

--- a/rpcs3/Loader/TROPUSR.cpp
+++ b/rpcs3/Loader/TROPUSR.cpp
@@ -116,12 +116,32 @@ bool TROPUSRLoader::LoadTables()
 		return false;
 	}
 
+	const u64 file_size = m_file.size();
+
+	auto fits_in_file = [&](u64 offset, u64 count, u64 entry_size) -> bool
+	{
+		// Reject obviously bogus headers (overflow or read past EOF) before seeking.
+		if (entry_size == 0)
+			return false;
+		if (count > file_size / entry_size)
+			return false;
+		const u64 total = count * entry_size;
+		if (offset > file_size || total > file_size - offset)
+			return false;
+		return true;
+	};
+
 	for (const TROPUSRTableHeader& tableHeader : m_tableHeaders)
 	{
-		m_file.seek(tableHeader.offset);
-
 		if (tableHeader.type == 4u)
 		{
+			if (!fits_in_file(tableHeader.offset, tableHeader.entries_count, sizeof(TROPUSREntry4)))
+			{
+				trp_log.error("TROPUSR table4 out of bounds (offset=0x%llx, entries=0x%x, file=0x%llx)", +tableHeader.offset, +tableHeader.entries_count, file_size);
+				return false;
+			}
+
+			m_file.seek(tableHeader.offset);
 			m_table4.clear();
 
 			if (!m_file.read(m_table4, tableHeader.entries_count))
@@ -130,6 +150,13 @@ bool TROPUSRLoader::LoadTables()
 
 		if (tableHeader.type == 6u)
 		{
+			if (!fits_in_file(tableHeader.offset, tableHeader.entries_count, sizeof(TROPUSREntry6)))
+			{
+				trp_log.error("TROPUSR table6 out of bounds (offset=0x%llx, entries=0x%x, file=0x%llx)", +tableHeader.offset, +tableHeader.entries_count, file_size);
+				return false;
+			}
+
+			m_file.seek(tableHeader.offset);
 			m_table6.clear();
 
 			if (!m_file.read(m_table6, tableHeader.entries_count))

--- a/rpcs3/Loader/mself.hpp
+++ b/rpcs3/Loader/mself.hpp
@@ -31,6 +31,10 @@ struct mself_header
 
 	u32 get_count(u64 file_size) const
 	{
+		// Reject undersized files outright so the subtraction below cannot underflow.
+		if (file_size < sizeof(mself_header)) [[unlikely]]
+			return 0;
+
 		// Fast sanity check
 		if (magic != "MSF"_u32 || ver != u32{1} || (file_size - sizeof(mself_header)) / sizeof(mself_record) < count || this->size != file_size) [[unlikely]]
 			return 0;

--- a/rpcs3/rpcs3qt/trophy_manager_dialog.cpp
+++ b/rpcs3/rpcs3qt/trophy_manager_dialog.cpp
@@ -496,12 +496,20 @@ bool trophy_manager_dialog::LoadTrophyFolderToDB(const std::string& trop_name)
 		return false;
 	}
 
-	const u32 trophy_count = game_trophy_data->trop_usr->GetTrophiesCount();
+	u32 trophy_count = game_trophy_data->trop_usr->GetTrophiesCount();
 
 	if (trophy_count == 0)
 	{
 		gui_log.error("Warning game %s in trophy folder %s usr file reports zero trophies. Cannot load in trophy manager.", game_trophy_data->game_name, game_trophy_data->path);
 		return false;
+	}
+
+	// Sanity bound: real PSN games have far fewer than this, but clamp to avoid runaway allocations from a malformed TROPUSR.DAT
+	constexpr u32 max_trophy_count = 1024;
+	if (trophy_count > max_trophy_count)
+	{
+		gui_log.warning("Trophy count %u for game %s exceeds sane maximum of %u, clamping", trophy_count, game_trophy_data->game_name, max_trophy_count);
+		trophy_count = max_trophy_count;
 	}
 
 	for (u32 trophy_id = 0; trophy_id < trophy_count; ++trophy_id)
@@ -1250,17 +1258,19 @@ void trophy_manager_dialog::PopulateTrophyTable()
 		// Get trophy type
 		QString trophy_type;
 
-		switch (n->GetAttribute("ttype")[0])
+		const std::string ttype_attr = n->GetAttribute("ttype");
+		switch (ttype_attr.empty() ? '\0' : ttype_attr[0])
 		{
 		case 'B': details.trophyGrade = SCE_NP_TROPHY_GRADE_BRONZE;   trophy_type = tr("Bronze", "Trophy type");   break;
 		case 'S': details.trophyGrade = SCE_NP_TROPHY_GRADE_SILVER;   trophy_type = tr("Silver", "Trophy type");   break;
 		case 'G': details.trophyGrade = SCE_NP_TROPHY_GRADE_GOLD;     trophy_type = tr("Gold", "Trophy type");     break;
 		case 'P': details.trophyGrade = SCE_NP_TROPHY_GRADE_PLATINUM; trophy_type = tr("Platinum", "Trophy type"); break;
-		default: gui_log.warning("Unknown trophy grade %s", n->GetAttribute("ttype")); break;
+		default: gui_log.warning("Unknown trophy grade %s", ttype_attr); break;
 		}
 
 		// Get hidden state
-		const bool hidden = n->GetAttribute("hidden")[0] == 'y';
+		const std::string hidden_attr = n->GetAttribute("hidden");
+		const bool hidden = hidden_attr == "yes";
 		details.hidden = hidden;
 
 		// Get name and detail


### PR DESCRIPTION
## Summary

Eighth hardening round. Base is PR #3 (claude/review-round-20260525); this PR adds 6 more per-subsystem commits. Same methodology — six parallel review agents per subsystem cluster, top critical claims verified by the PM, six parallel fix agents per commit theme.

### Per-commit overview

- **SPU: fix /41 instruction-index typo, BISL rc/rc, MFC debug dump OOB** — `SPUCommonRecompiler` reread loop was `result.data[(ia - lsa) / 41]` instead of `/4` (regressed in ff42459239); BISL no-return heuristic for `use_rc` tested `ra`/`rb` instead of `rc`/`rc` (compare the parallel BRSL path); the MFC debug dump in the size-switch default arm called `memcpy` from `dst`/`src` after the copy loops had advanced them past the transfer end.

- **Input: fix fd leak, raw_mouse per-index, ps_move calibration** — `evdev_joystick_handler` leaked the fd when `libevdev_new_from_fd` failed; `raw_mouse_handler` wrote `vendor_id[0]`/`product_id[0]` inside a per-index loop; `ps_move_calibration` used `x1` for the Y and Z accel offsets and divided by attacker-controlled diffs without checking for zero; the calibration block-read loop iterated only twice on ZCM1 (needs 3 blocks).

- **Loader/Crypto: harden SELF/EDAT/PKG/ELF/TAR parsers** — Biggest commit of the round. `unself` had uninitialized `Read8/16/32/64` returns, an unbounded `metadata_headers_size`, a `cinfo.size == 0` infinite loop in the supplemental-header walk, unchecked seeks for every `m_ext_hdr.*_offset`, a u32 accumulator overflow into `data_buf_length` (heap overflow), and a `WriteElf` `data_buf_offset` desync against `DecryptData`'s decrypt filter; also non-NUL-terminated `content_id` (0x30 chars) being implicitly used as `std::string`. `unedat` mirrored the `content_id` fix, swapped the throwing `narrow<u32>` for a logged failure, and added `add_saturate` in `ReadData`. `unpkg` saturates `data_size+data_offset`, caps the install_dir packet, the `meta_count`, and the `file_count` before resize. `ELF.h` caps `p_filesz` against stream size. `TROPUSR` validates offset+count*size. `mself` guards `get_count` underflow. `TAR` splits path on `/` and rejects any `..`/`.` component.

- **sys_*: bound rsxaudio/ss/hid/net/config guest inputs and savestate** — `sys_rsxaudio` modulo'd by guest-writable shared-memory fields (host divide-by-zero) and didn't validate `shmem` from savestate. `sys_ss` wrote through guest pointers (`random_number_generator`, `access_control_engine`, `secure_rtc`, `individual_info_manager`) without `vm::check_addr`; `update_manager` allocated unbounded guest memory. `sys_hid_manager_read` computed `cpySize = buf_size * 2` (2× guest buffer overflow); `sys_hid_manager_ioctl` cast `buf` without null/size checks. `sys_net_bnet_setsockopt` dereferenced `optval` in the debug log before bounds; `sys_net_bnet_poll` allowed up to ~16 GiB `fds_buf` allocation; `infoctl cmd 9` did a double-indirection write; `lv2_socket::load` had no `default:` arm. `sys_config` passed unbounded guest size to a constructor that does `data(&_data[0], &_data[size])`.

- **cellGif/Jpg/Png/Pamf/Search/SubDisplay/sceNp: bound decoder/IPC inputs** — `cellGifDec` and `cellJpgDec` allocated `uint[image_size]` / `vector<u32>(image_size)` where `image_size` is in bytes (4× oversize → 4 GiB at the existing cap). `cellPngDec` had unbounded `streamSize`/`bytes_per_line`/progressive-decode loop, plus `row_num < outputStartY` underflow. `cellPamf` verifier's unsigned subtractions could wrap and bypass the integrity check. `cellSearch` indexed `tags[tagNum]` (off the end) in its per-tag validation loop, and used `sizeof(...->data.photo)` for the video case. `cellSubDisplay` had a signed-compare miss on `*pNumTouchInfo`. `sceNp` `LookupTitleSmallStorageAsync` and `record_score` both took unbounded sizes.

- **cheats/trophy_manager: validate clipboard input and bound trophy count** — `cheat_info::from_str` used `std::stoul` (throws), reachable via the "Import Cheats" clipboard menu. `trophy_manager_dialog` accepted attacker-controlled `trophy_count` from `TROPUSR.DAT` (4 GiB QString map possible) and indexed `GetAttribute("ttype")[0]` rather than comparing the full string.

## Methodology

Six parallel read-only review agents (SPU, Input, Loader+VFS+Crypto, remaining sys_*, image decoders + NP, patch/PKG/cheats) returned ~90 findings. The PM verified the critical claims (SPU `/41` typo, sys_rsxaudio div-by-zero, unself u32 accumulator overflow, sys_hid 2× overflow) by reading the cited file:line directly, then dispatched six parallel fix agents per commit theme. Each fix agent was told to skip findings the surrounding code didn't support (~10–15 were skipped as too speculative or already-safe on re-reading).

## Test plan

- [ ] CI build passes on Windows + Linux + macOS.
- [ ] Boot a representative title to confirm the SPU `/41` fix doesn't regress the giga-block analyser path.
- [ ] Decode a normal GIF/JPG/PNG to confirm the decoder allocation fixes don't break valid images.
- [ ] Plug/unplug a PS Move (ZCM1 and ZCM2) and confirm calibration loads with no Inf/NaN orientations.
- [ ] Attempt to load a hand-crafted SELF / EDAT / PKG with the previously-exploitable headers and confirm it fails cleanly instead of crashing or executing.

## Stacking

This PR is based on PR #3 (round 7) — merging that first will make this one apply cleanly against master.

🤖 Generated with [Claude Code](https://claude.com/claude-code)